### PR TITLE
Added AutoStartSimulation support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Main from "./containers/Main";
 import { useStoreActions, useStoreState } from "./hooks";
 import { track } from "./utils/metrics";
 import NewSimulation from "./containers/NewSimulation";
+import AutoStartSimulation from "./components/AutoStartSimulation";
 const { Sider } = Layout;
 
 type MenuItem = Required<MenuProps>["items"][number];
@@ -225,6 +226,7 @@ const App: React.FC = () => {
           />
         </Sider>
         <Layout className="site-layout">
+          <AutoStartSimulation />
           <Simulation />
           <Main />
         </Layout>

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from "react";
+import { useStoreActions, useStoreState } from "../hooks";
+import { Simulation } from "../store/simulation";
+import { notification } from "antd";
+
+declare global {
+  interface Window {
+    wasm: any; // Replace 'any' with the actual type if known
+  }
+}
+
+interface Example {
+  id: string;
+  title: string;
+  description: string;
+  analysisDescription?: string;
+  analysisScript?: string;
+  imageUrl: string;
+  inputScript: string;
+  keywords?: string[];
+  files: {
+    fileName: string;
+    url: string;
+  }[];
+}
+
+interface ExamplesData {
+  baseUrl: string;
+  title: string;
+  descriptionFile: string;
+  examples: Example[];
+}
+
+const AutoStartSimulation = () => {
+  const hasInitiatedStart = useRef(false);
+  const setNewSimulation = useStoreActions(
+    (actions) => actions.simulation.newSimulation
+  );
+  const setPreferredView = useStoreActions(
+    (actions) => actions.app.setPreferredView
+  );
+  const running = useStoreState((state) => state.simulation.running);
+  const simulation = useStoreState((state) => state.simulation.simulation);
+  
+  useEffect(() => {
+    const fetchAndStartSimulation = async () => {
+      const urlSearchParams = new URLSearchParams(window.location.search);
+      const embeddedSimulationUrl = urlSearchParams.get('embeddedSimulationUrl');
+      const simulationIndex = parseInt(urlSearchParams.get('simulationIndex') || '0', 10);
+
+      if (!embeddedSimulationUrl) {
+        return;
+      }
+      
+      try {
+        const response = await fetch(embeddedSimulationUrl);
+        const data: ExamplesData = await response.json();
+        
+        // If we have a valid simulation index, start that simulation
+        if (simulationIndex >= 0 && simulationIndex < data.examples.length) {
+          const selectedExample = data.examples[simulationIndex];
+          
+          // Update all URLs with baseUrl
+          selectedExample.imageUrl = `${data.baseUrl}/${selectedExample.imageUrl}`;
+          if (selectedExample.analysisScript) {
+            selectedExample.analysisScript = `${data.baseUrl}/${selectedExample.analysisScript}`;
+          }
+          selectedExample.files.forEach((file) => {
+            file.url = `${data.baseUrl}/${file.url}`;
+          });
+
+          const newSimulation: Simulation = {
+            id: selectedExample.id,
+            inputScript: selectedExample.inputScript,
+            files: selectedExample.files,
+            analysisDescription: selectedExample.analysisDescription,
+            analysisScript: selectedExample.analysisScript,
+            start: true
+          };
+
+          if (simulation?.id !== newSimulation.id) {
+            hasInitiatedStart.current = true;
+            setNewSimulation(newSimulation);
+            setPreferredView("view");
+          }
+        }
+      } catch (error) {
+        console.error("Error fetching examples data:", error);
+        notification.error({
+          message: "Error loading simulation",
+          description: "Could not load the simulation data from the provided URL.",
+        });
+      }
+    };
+
+    const checkWasmAndStart = () => {
+      if (!window.wasm) {
+        setTimeout(checkWasmAndStart, 500);
+        return;
+      }
+
+      if (!hasInitiatedStart.current && !running) {
+        fetchAndStartSimulation();
+      }
+    };
+
+    checkWasmAndStart();
+  }, [running, simulation?.id, setNewSimulation, setPreferredView]);
+
+  return null; // This component doesn't render anything
+};
+
+export default AutoStartSimulation;

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -48,7 +48,7 @@ const AutoStartSimulation = () => {
       const embeddedSimulationUrl = urlSearchParams.get('embeddedSimulationUrl');
       const simulationIndex = parseInt(urlSearchParams.get('simulationIndex') || '0', 10);
 
-      if (!embeddedSimulationUrl) {
+      if (!embeddedSimulationUrl || !simulationIndex) {
         return;
       }
       

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -84,12 +84,13 @@ const AutoStartSimulation = () => {
             setPreferredView("view");
           }
         }
-      } catch (error) {
+      } catch (error: any) { // Explicitly type 'error' as 'any'
         console.error("Error fetching examples data:", error);
         notification.error({
           message: "Error loading simulation",
-          description: "Could not load the simulation data from the provided URL.",
+          description: `Could not load the simulation data from the provided URL. Details: ${error.message || error}`, // Include error message
         });
+      }
       }
     };
 

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -2,10 +2,11 @@ import { useEffect, useRef } from "react";
 import { useStoreActions, useStoreState } from "../hooks";
 import { Simulation } from "../store/simulation";
 import { notification } from "antd";
+import React from "react";
 
 declare global {
   interface Window {
-    wasm: any; // Replace 'any' with the actual type if known
+    wasm: any;
   }
 }
 
@@ -31,7 +32,7 @@ interface ExamplesData {
   examples: Example[];
 }
 
-const AutoStartSimulation = () => {
+const AutoStartSimulation: React.FC = () => {
   const hasInitiatedStart = useRef(false);
   const setNewSimulation = useStoreActions(
     (actions) => actions.simulation.newSimulation
@@ -56,11 +57,9 @@ const AutoStartSimulation = () => {
         const response = await fetch(embeddedSimulationUrl);
         const data: ExamplesData = await response.json();
         
-        // If we have a valid simulation index, start that simulation
         if (simulationIndex >= 0 && simulationIndex < data.examples.length) {
           const selectedExample = data.examples[simulationIndex];
           
-          // Update all URLs with baseUrl
           selectedExample.imageUrl = `${data.baseUrl}/${selectedExample.imageUrl}`;
           if (selectedExample.analysisScript) {
             selectedExample.analysisScript = `${data.baseUrl}/${selectedExample.analysisScript}`;
@@ -84,30 +83,30 @@ const AutoStartSimulation = () => {
             setPreferredView("view");
           }
         }
-      } catch (error: any) { // Explicitly type 'error' as 'any'
+      } catch (error) {
         console.error("Error fetching examples data:", error);
         notification.error({
           message: "Error loading simulation",
-          description: `Could not load the simulation data from the provided URL. Details: ${error.message || error}`, // Include error message
+          description: `Could not load the simulation data from the provided URL. Details: ${error instanceof Error ? error.message : String(error)}`,
         });
       }
     };
-const checkWasmAndStart = () => {
-  if (!window.wasm) {
-    const timeoutId = setTimeout(checkWasmAndStart, 500);
-    return () => clearTimeout(timeoutId);
-  }
 
-  if (!hasInitiatedStart.current && !running) {
-    fetchAndStartSimulation();
-  }
-};
+    const checkWasmAndStart = () => {
+      if (!window.wasm) {
+        setTimeout(checkWasmAndStart, 500);
+        return;
+      }
+
+      if (!hasInitiatedStart.current && !running) {
+        fetchAndStartSimulation();
+      }
     };
 
     checkWasmAndStart();
   }, [simulation?.id, running, setNewSimulation, setPreferredView]);
 
-  return null; // This component doesn't render anything visible
+  return null;
 };
 
 export default AutoStartSimulation;

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -91,7 +91,6 @@ const AutoStartSimulation = () => {
           description: `Could not load the simulation data from the provided URL. Details: ${error.message || error}`, // Include error message
         });
       }
-      }
     };
 const checkWasmAndStart = () => {
   if (!window.wasm) {
@@ -106,9 +105,9 @@ const checkWasmAndStart = () => {
     };
 
     checkWasmAndStart();
-  }, [running, simulation?.id, setNewSimulation, setPreferredView]);
+  }, [simulation?.id, running, setNewSimulation, setPreferredView]);
 
-  return null; // This component doesn't render anything
+  return null; // This component doesn't render anything visible
 };
 
 export default AutoStartSimulation;

--- a/src/components/AutoStartSimulation.tsx
+++ b/src/components/AutoStartSimulation.tsx
@@ -93,16 +93,16 @@ const AutoStartSimulation = () => {
       }
       }
     };
+const checkWasmAndStart = () => {
+  if (!window.wasm) {
+    const timeoutId = setTimeout(checkWasmAndStart, 500);
+    return () => clearTimeout(timeoutId);
+  }
 
-    const checkWasmAndStart = () => {
-      if (!window.wasm) {
-        setTimeout(checkWasmAndStart, 500);
-        return;
-      }
-
-      if (!hasInitiatedStart.current && !running) {
-        fetchAndStartSimulation();
-      }
+  if (!hasInitiatedStart.current && !running) {
+    fetchAndStartSimulation();
+  }
+};
     };
 
     checkWasmAndStart();


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced `AutoStartSimulation` component for automatic simulation initialization.

- Integrated `AutoStartSimulation` into the main application layout.

- Added logic to fetch and start simulations based on URL parameters.

- Enhanced error handling for simulation data loading failures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Integrate `AutoStartSimulation` into main layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.tsx

<li>Imported <code>AutoStartSimulation</code> component.<br> <li> Added <code>AutoStartSimulation</code> to the main application layout.


</details>


  </td>
  <td><a href="https://github.com/andeplane/atomify/pull/145/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AutoStartSimulation.tsx</strong><dd><code>Add `AutoStartSimulation` component with initialization logic</code></dd></summary>
<hr>

src/components/AutoStartSimulation.tsx

<li>Created <code>AutoStartSimulation</code> component.<br> <li> Added logic to fetch simulation data from URL.<br> <li> Implemented automatic simulation initialization.<br> <li> Included error handling for data fetching issues.


</details>


  </td>
  <td><a href="https://github.com/andeplane/atomify/pull/145/files#diff-0d07a5dbfa96733379f03205532ae18922cbb6fc837d6f9148246b493b6d9906">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>