### PR TITLE
Handle missing notebook file error

### DIFF
--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -468,6 +468,9 @@ export const simulationModel: SimulationModel = {
       actions.setShowConsole(false);
       actions.setSimulation(simulation);
       actions.resetLammpsOutput();
+      
+      // Create notebook files for JupyterLite when simulation is loaded
+      actions.syncFilesJupyterLite();
 
       // Reset potentially chosen per atom coloring
       const postTimestepModifiers =


### PR DESCRIPTION
Call `syncFilesJupyterLite` when a new simulation is loaded to prevent "Could not find content with path analyze.ipynb" error.

The `analyze.ipynb` file was only created when a simulation ran. However, the Notebook tab could be accessed before a simulation was run, leading to JupyterLite trying to load a non-existent file. Calling `syncFilesJupyterLite` upon simulation loading ensures the file is present when the Notebook tab is accessed.

---
<a href="https://cursor.com/background-agent?bcId=bc-664f7d44-ab55-493b-b1ee-cd735d43e41e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-664f7d44-ab55-493b-b1ee-cd735d43e41e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

