### PR TITLE
Fix notebook file not found error

### DIFF
--- a/src/containers/Notebook.tsx
+++ b/src/containers/Notebook.tsx
@@ -1,13 +1,46 @@
 import Iframe from "react-iframe";
 import { useStoreState } from "../hooks";
+import { useEffect, useState } from "react";
+import localforage from "localforage";
+
 const Notebook = () => {
   const simulation = useStoreState((state) => state.simulation.simulation);
+  const [notebookUrl, setNotebookUrl] = useState<string>("/atomify/jupyter/lab/index.html");
 
-  let notebookUrl = `/atomify/jupyter/lab/index.html?path=analyze.ipynb`;
-  if (simulation?.analysisScript) {
-    const analysisScriptPath = `${simulation.id}/${simulation.analysisScript}`;
-    notebookUrl = `/atomify/jupyter/lab/index.html?path=${analysisScriptPath}`;
-  }
+  useEffect(() => {
+    const determineNotebookUrl = async () => {
+      let url = "/atomify/jupyter/lab/index.html";
+
+      if (simulation?.analysisScript) {
+        // If simulation has a specific analysis script, use that
+        const analysisScriptPath = `${simulation.id}/${simulation.analysisScript}`;
+        try {
+          const analysisNotebook = await localforage.getItem(analysisScriptPath);
+          if (analysisNotebook) {
+            url = `/atomify/jupyter/lab/index.html?path=${analysisScriptPath}`;
+          }
+        } catch (error) {
+          console.log("Could not check for analysis script existence:", error);
+        }
+      } else {
+        // Check if analyze.ipynb exists in localforage before using it
+        try {
+          const analyzeNotebook = await localforage.getItem("analyze.ipynb");
+          if (analyzeNotebook) {
+            url = "/atomify/jupyter/lab/index.html?path=analyze.ipynb";
+          }
+          // If analyze.ipynb doesn't exist, just use the base JupyterLab URL
+        } catch (error) {
+          console.log("Could not check for analyze.ipynb existence:", error);
+          // Fall back to base URL without specific path
+        }
+      }
+
+      setNotebookUrl(url);
+    };
+
+    determineNotebookUrl();
+  }, [simulation]);
 
   return (
     <>

--- a/src/containers/Notebook.tsx
+++ b/src/containers/Notebook.tsx
@@ -8,6 +8,7 @@ const Notebook = () => {
   const [notebookUrl, setNotebookUrl] = useState<string>("/atomify/jupyter/lab/index.html");
 
   useEffect(() => {
+    let isMounted = true;
     const determineNotebookUrl = async () => {
       const baseUrl = "/atomify/jupyter/lab/index.html";
       let url = baseUrl;
@@ -24,10 +25,16 @@ const Notebook = () => {
         console.log(`Could not check for notebook existence at "${path}":`, error);
       }
 
-      setNotebookUrl(url);
+      if (isMounted) {
+        setNotebookUrl(url);
+      }
     };
 
     determineNotebookUrl();
+
+    return () => {
+      isMounted = false;
+    };
   }, [simulation]);
 
   return (

--- a/src/containers/Notebook.tsx
+++ b/src/containers/Notebook.tsx
@@ -9,31 +9,19 @@ const Notebook = () => {
 
   useEffect(() => {
     const determineNotebookUrl = async () => {
-      let url = "/atomify/jupyter/lab/index.html";
+      const baseUrl = "/atomify/jupyter/lab/index.html";
+      let url = baseUrl;
 
-      if (simulation?.analysisScript) {
-        // If simulation has a specific analysis script, use that
-        const analysisScriptPath = `${simulation.id}/${simulation.analysisScript}`;
-        try {
-          const analysisNotebook = await localforage.getItem(analysisScriptPath);
-          if (analysisNotebook) {
-            url = `/atomify/jupyter/lab/index.html?path=${analysisScriptPath}`;
-          }
-        } catch (error) {
-          console.log("Could not check for analysis script existence:", error);
+      const path = simulation?.analysisScript
+        ? `${simulation.id}/${simulation.analysisScript}`
+        : "analyze.ipynb";
+
+      try {
+        if (await localforage.getItem(path)) {
+          url = `${baseUrl}?path=${path}`;
         }
-      } else {
-        // Check if analyze.ipynb exists in localforage before using it
-        try {
-          const analyzeNotebook = await localforage.getItem("analyze.ipynb");
-          if (analyzeNotebook) {
-            url = "/atomify/jupyter/lab/index.html?path=analyze.ipynb";
-          }
-          // If analyze.ipynb doesn't exist, just use the base JupyterLab URL
-        } catch (error) {
-          console.log("Could not check for analyze.ipynb existence:", error);
-          // Fall back to base URL without specific path
-        }
+      } catch (error) {
+        console.log(`Could not check for notebook existence at "${path}":`, error);
       }
 
       setNotebookUrl(url);

--- a/src/containers/Notebook.tsx
+++ b/src/containers/Notebook.tsx
@@ -13,9 +13,11 @@ const Notebook = () => {
       const baseUrl = "/atomify/jupyter/lab/index.html";
       let url = baseUrl;
 
-      const path = simulation?.analysisScript
-        ? `${simulation.id}/${simulation.analysisScript}`
-        : "analyze.ipynb";
+      let path = "analyze.ipynb";
+      if (simulation?.analysisScript) {
+        const scriptName = simulation.analysisScript.substring(simulation.analysisScript.lastIndexOf('/') + 1);
+        path = `${simulation.id}/${scriptName}`;
+      }
 
       try {
         if (await localforage.getItem(path)) {

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -468,6 +468,9 @@ export const simulationModel: SimulationModel = {
       actions.setShowConsole(false);
       actions.setSimulation(simulation);
       actions.resetLammpsOutput();
+      
+      // Sync files to JupyterLite storage so they're available immediately
+      actions.syncFilesJupyterLite();
 
       // Reset potentially chosen per atom coloring
       const postTimestepModifiers =

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -468,9 +468,6 @@ export const simulationModel: SimulationModel = {
       actions.setShowConsole(false);
       actions.setSimulation(simulation);
       actions.resetLammpsOutput();
-      
-      // Sync files to JupyterLite storage so they're available immediately
-      actions.syncFilesJupyterLite();
 
       // Reset potentially chosen per atom coloring
       const postTimestepModifiers =
@@ -534,6 +531,10 @@ export const simulationModel: SimulationModel = {
 
       actions.setSimulation(simulation); // Set it again now that files are updated
       wasm.FS.chdir(`/${simulation.id}`);
+      
+      // Sync files to JupyterLite storage now that they're available in WASM filesystem
+      actions.syncFilesJupyterLite();
+      
       await allActions.app.setStatus(undefined);
       if (simulation.start) {
         actions.run();

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -533,7 +533,7 @@ export const simulationModel: SimulationModel = {
       wasm.FS.chdir(`/${simulation.id}`);
       
       // Sync files to JupyterLite storage now that they're available in WASM filesystem
-      actions.syncFilesJupyterLite();
+      await actions.syncFilesJupyterLite();
       
       await allActions.app.setStatus(undefined);
       if (simulation.start) {


### PR DESCRIPTION
Fixes the 'Could not find content with path analyze.ipynb' error in JupyterLite.

## Problem
Users were encountering an error when clicking on the Notebook tab before running a simulation, because the analyze.ipynb file wasn't created until after the simulation ran.

## Solution
1. **Early File Syncing**: Added syncFilesJupyterLite() call in newSimulation thunk so files are synced to JupyterLite storage immediately when a simulation is loaded
2. **Proper File Existence Checking**: Modified Notebook.tsx to check if files exist in localforage before using them in URLs
3. **Correct File Paths**: Fixed the file path checking to use the correct keys for both analyze.ipynb and simulation-specific analysis scripts

## Changes
- Modified src/store/simulation.ts to sync files early in newSimulation
- Updated src/containers/Notebook.tsx to check file existence and use correct paths
- Added graceful fallback to base JupyterLab URL when files don't exist

This ensures users can access the Notebook tab immediately without errors, while maintaining backward compatibility with existing analysis scripts.