### PR TITLE
Ensure build folder is gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cpp/obj
 cpp/lammps.mjs
 cpp/lammps.wasm
 cpp/lammps.worker.js
+build/


### PR DESCRIPTION
Add `build/` to `.gitignore` to prevent build artifacts from being tracked.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9c4fd1c-c28c-4510-9646-5338b373d4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9c4fd1c-c28c-4510-9646-5338b373d4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

