### PR TITLE
feat: add recompile and debug build options for LAMMPS

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -33,8 +33,8 @@ obj/%.o: lammps/src/%.cpp
 	$(CXX) $(CC_FLAGS) $(INCLUDE_FLAGS) -c -o $@ $<
 
 # Dependencies for lammpsweb files
-$(foreach file,$(LAMMPSWEB_FILES),obj/$(file).o): obj/%.o: lammpsweb/%.cpp lammpsweb/%.h
-	$(CXX) $(CC_FLAGS) $(INCLUDE_FLAGS) -c -o $@ lammps/src/$*.cpp
+$(foreach file,$(LAMMPSWEB_FILES),obj/$(file).o): obj/%.o: lammpsweb/%.cpp lammpsweb/%.h lammps/src/%.cpp lammps/src/%.h
+	$(CXX) $(CC_FLAGS) $(INCLUDE_FLAGS) -c -o $@ lammpsweb/$*.cpp
 
 clean:
 	rm lammps.mjs; rm lammps.wasm; rm obj/*

--- a/cpp/build.py
+++ b/cpp/build.py
@@ -81,18 +81,21 @@ copy_atomify_files()
 # Check if recompile flag is passed
 if "--recompile" in sys.argv or "-r" in sys.argv:
   print("Running clean to force full recompilation...")
-  subprocess.call("make clean", shell=True)
+  clean_result = subprocess.call(["make", "clean"])
+  if clean_result != 0:
+    print(f"'make clean' failed with exit code {clean_result}. Aborting.")
+    sys.exit(clean_result)
   print("Clean complete, proceeding with build...")
 
 # Check if DEBUG flag is passed
-debug_flag = ""
+build_env = os.environ.copy()
 if "--debug" in sys.argv or "-d" in sys.argv:
-  debug_flag = "DEBUG=1 "
+  build_env["DEBUG"] = "1"
   print("Building in DEBUG mode with source maps and symbols...")
 else:
   print("Building in RELEASE mode (optimized)...")
 
-result = subprocess.call(f"make -j8 {debug_flag}", shell=True)
+result = subprocess.call(["make", "-j8"], env=build_env)
 if result != 0:
   print(f"Build failed with exit code {result}")
   sys.exit(result)


### PR DESCRIPTION
This PR adds support for recompiling LAMMPS and debugging builds:

**Changes:**
- Added `--recompile`/`-r` flag to `build.py` to force full recompilation (runs `make clean` first)
- Added `--debug`/`-d` flag to `build.py` to enable debug builds with source maps
- Updated Makefile to include lammpsweb file dependencies
- Added HEAP32, HEAPF32, HEAPF64 to EXPORTED_RUNTIME_METHODS for better memory access
- Improved error handling in build.py to check for wasm file generation
- Removed USE_ES6_IMPORT_META=0 flag (no longer needed)

**Build improvements:**
- Better error messages when build fails
- Validation that lammps.wasm was generated before copying
- Support for debug builds with source maps for easier debugging