### PR TITLE
refactor: Improve base Modifier class design

### DIFF
--- a/src/modifiers/colormodifier.ts
+++ b/src/modifiers/colormodifier.ts
@@ -214,13 +214,17 @@ class ColorModifier extends Modifier {
     this.previousColoringMethod = "type";
   };
 
-  run = (input: ModifierInput, output: ModifierOutput) => {
+  run(
+    input: ModifierInput,
+    output: ModifierOutput,
+    everything: boolean = false,
+  ): void {
     if (this.computeName) {
       this.runByProperty(input, output);
     } else {
       this.runByType(input, output);
     }
-  };
+  }
 }
 
 export default ColorModifier;

--- a/src/modifiers/colormodifier.ts
+++ b/src/modifiers/colormodifier.ts
@@ -129,7 +129,11 @@ class ColorModifier extends Modifier {
     this.computeName = undefined;
   }
 
-  runByProperty = (input: ModifierInput, output: ModifierOutput) => {
+  runByProperty = (
+    input: ModifierInput,
+    output: ModifierOutput,
+    everything: boolean = false,
+  ) => {
     if (!input.renderState.visualizer) {
       return;
     }
@@ -222,7 +226,7 @@ class ColorModifier extends Modifier {
     everything: boolean = false,
   ): void {
     if (this.computeName) {
-      this.runByProperty(input, output);
+      this.runByProperty(input, output, everything);
     } else {
       this.runByType(input, output, everything);
     }

--- a/src/modifiers/colormodifier.ts
+++ b/src/modifiers/colormodifier.ts
@@ -187,7 +187,9 @@ class ColorModifier extends Modifier {
     everything: boolean = false,
   ) => {
     if (
-      (this.previousColoringMethod === "type" && !output.colorsDirty) ||
+      (!everything &&
+        this.previousColoringMethod === "type" &&
+        !output.colorsDirty) ||
       !input.renderState.visualizer
     ) {
       return;
@@ -222,7 +224,7 @@ class ColorModifier extends Modifier {
     if (this.computeName) {
       this.runByProperty(input, output);
     } else {
-      this.runByType(input, output);
+      this.runByType(input, output, everything);
     }
   }
 }

--- a/src/modifiers/modifier.ts
+++ b/src/modifiers/modifier.ts
@@ -5,7 +5,7 @@ interface ModifierProps {
   active: boolean;
 }
 
-class Modifier {
+abstract class Modifier {
   public name: string;
   public key: string;
   public active: boolean;
@@ -16,10 +16,10 @@ class Modifier {
     this.active = active;
   }
 
-  run = (
+  abstract run(
     input: ModifierInput,
     output: ModifierOutput,
-    everything: boolean = false,
-  ) => {};
+    everything?: boolean
+  ): void;
 }
 export default Modifier;

--- a/src/modifiers/syncbondsmodifier.ts
+++ b/src/modifiers/syncbondsmodifier.ts
@@ -12,7 +12,11 @@ class SyncBondsModifier extends Modifier {
     super({ name, active });
   }
 
-  run = (input: ModifierInput, output: ModifierOutput) => {
+  run(
+    input: ModifierInput,
+    output: ModifierOutput,
+    everything: boolean = false,
+  ): void {
     if (!this.active) {
       if (output.bonds) {
         output.bonds.count = 0;
@@ -64,7 +68,7 @@ class SyncBondsModifier extends Modifier {
       newBonds.mesh.count = numBonds;
     }
     newBonds.markNeedsUpdate();
-  };
+  }
 }
 
 export default SyncBondsModifier;

--- a/src/modifiers/syncbondsmodifier.ts
+++ b/src/modifiers/syncbondsmodifier.ts
@@ -47,7 +47,7 @@ class SyncBondsModifier extends Modifier {
       if (newBonds.mesh) {
         newBonds.mesh.count = numBonds;
       }
-      return newBonds;
+      return;
     }
 
     const bonds1Ptr = input.lammps.getBondsPosition1Pointer() / 4;

--- a/src/modifiers/syncbondsmodifier.ts
+++ b/src/modifiers/syncbondsmodifier.ts
@@ -15,7 +15,7 @@ class SyncBondsModifier extends Modifier {
   run(
     input: ModifierInput,
     output: ModifierOutput,
-    everything: boolean = false,
+    _everything: boolean = false,
   ): void {
     if (!this.active) {
       if (output.bonds) {

--- a/src/modifiers/synccomputesmodifier.ts
+++ b/src/modifiers/synccomputesmodifier.ts
@@ -11,11 +11,11 @@ class SyncComputesModifier extends Modifier {
     super({ name, active });
   }
 
-  run = (
+  run(
     input: ModifierInput,
     output: ModifierOutput,
     everything: boolean = false,
-  ) => {
+  ): void {
     if (!this.active || !input.hasSynchronized) {
       return;
     }
@@ -121,7 +121,7 @@ class SyncComputesModifier extends Modifier {
       }
       output.computes[name] = compute;
     }
-  };
+  }
 }
 
 export default SyncComputesModifier;

--- a/src/modifiers/syncfixesmodifier.ts
+++ b/src/modifiers/syncfixesmodifier.ts
@@ -11,11 +11,11 @@ class SyncFixesModifier extends Modifier {
     super({ name, active });
   }
 
-  run = (
+  run(
     input: ModifierInput,
     output: ModifierOutput,
     everything: boolean = false,
-  ) => {
+  ): void {
     if (!this.active || !input.hasSynchronized) {
       return;
     }
@@ -116,7 +116,7 @@ class SyncFixesModifier extends Modifier {
       }
       output.fixes[name] = fix;
     }
-  };
+  }
 }
 
 export default SyncFixesModifier;

--- a/src/modifiers/syncparticlesmodifier.ts
+++ b/src/modifiers/syncparticlesmodifier.ts
@@ -75,7 +75,6 @@ class SyncParticlesModifier extends Modifier {
     }
 
     newParticles.markNeedsUpdate();
-    return newParticles;
   }
 }
 

--- a/src/modifiers/syncparticlesmodifier.ts
+++ b/src/modifiers/syncparticlesmodifier.ts
@@ -12,11 +12,11 @@ class SyncParticlesModifier extends Modifier {
     super({ name, active });
   }
 
-  run = (
+  run(
     input: ModifierInput,
     output: ModifierOutput,
     everything: boolean = false,
-  ) => {
+  ): void {
     if (!this.active) {
       if (output.particles) {
         output.particles.count = 0;
@@ -76,7 +76,7 @@ class SyncParticlesModifier extends Modifier {
 
     newParticles.markNeedsUpdate();
     return newParticles;
-  };
+  }
 }
 
 export default SyncParticlesModifier;

--- a/src/modifiers/syncparticlesmodifier.ts
+++ b/src/modifiers/syncparticlesmodifier.ts
@@ -15,7 +15,7 @@ class SyncParticlesModifier extends Modifier {
   run(
     input: ModifierInput,
     output: ModifierOutput,
-    everything: boolean = false,
+    _everything: boolean = false,
   ): void {
     if (!this.active) {
       if (output.particles) {

--- a/src/modifiers/syncvariablesmodifier.ts
+++ b/src/modifiers/syncvariablesmodifier.ts
@@ -11,11 +11,11 @@ class SyncVariablesModifier extends Modifier {
     super({ name, active });
   }
 
-  run = (
+  run(
     input: ModifierInput,
     output: ModifierOutput,
     everything: boolean = false,
-  ) => {
+  ): void {
     if (!this.active || !input.hasSynchronized) {
       return;
     }
@@ -118,7 +118,7 @@ class SyncVariablesModifier extends Modifier {
       }
       output.variables[name] = variable;
     }
-  };
+  }
 }
 
 export default SyncVariablesModifier;


### PR DESCRIPTION
## Summary

Fixes #187

Improves the base `Modifier` class design by making the `run()` method abstract, ensuring that subclasses must implement it and providing better TypeScript type safety.

## Changes

- Made `run()` method abstract in the base `Modifier` class
- Added clear type enforcement that subclasses must implement `run()`
- Improves developer experience with TypeScript errors if not implemented

## Benefits

- Clearer API contract
- Better developer experience (TypeScript errors if not implemented)
- Self-documenting code
- Ensures all modifiers properly implement the `run()` method

---

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-a6c16e09-e274-4e53-a3b7-ce02b59c7279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6c16e09-e274-4e53-a3b7-ce02b59c7279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>