### PR TITLE
chore: Add PR creation workflow with draft status requirements

### DIFF
--- a/.cursor/rules/pull-requests-best-practices.mdc
+++ b/.cursor/rules/pull-requests-best-practices.mdc
@@ -54,3 +54,14 @@ Fixes #XXX (or Closes #XXX)
 
 [Any additional context, testing notes, etc.]
 ```
+
+## PR Creation Workflow
+
+When creating a pull request:
+1. Create the PR as a draft with proper title and description
+2. Wait 1 minute for Gemini PR reviewer to process and add comments
+3. Check for review comments
+4. If comments are not yet present, wait another 30 seconds
+5. Address any review comments from Gemini
+6. Keep the PR in draft status until all reviews are addressed
+7. Only mark the PR as ready for review once all review comments have been addressed


### PR DESCRIPTION
## Summary

Adds PR creation workflow guidelines to cursor rules, requiring PRs to be created as drafts and kept in draft status until all review comments are addressed.

## Changes

- Added PR Creation Workflow section to `.cursor/rules/pull-requests-best-practices.mdc`
- Workflow includes:
  - Creating PRs as draft initially
  - Waiting 1 minute for Gemini PR reviewer (plus 30s if needed)
  - Addressing all review comments
  - Keeping PRs in draft until all reviews are addressed
  - Only marking PR as ready after all reviews are completed

## Impact / Benefits

- Ensures all PRs go through proper review process before being marked ready
- Prevents premature PR approval by keeping them in draft status
- Standardizes the workflow for waiting on automated reviews

## Files Modified

- `.cursor/rules/pull-requests-best-practices.mdc`