### PR TITLE
fix: update reax/c to reaxff in all examples

### DIFF
--- a/public/examples/reaxff/AB/AB.in
+++ b/public/examples/reaxff/AB/AB.in
@@ -14,7 +14,7 @@ units		real
 atom_style	charge
 read_data	data.AB
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.AB H B N
 
 neighbor	2 bin

--- a/public/examples/reaxff/CHO/CHO.in
+++ b/public/examples/reaxff/CHO/CHO.in
@@ -15,7 +15,7 @@ units		real
 atom_style	charge
 read_data	data.CHO
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.cho H C O
 
 neighbor	2 bin

--- a/public/examples/reaxff/FeOH3/FeOH3.in
+++ b/public/examples/reaxff/FeOH3/FeOH3.in
@@ -13,7 +13,7 @@ units		real
 atom_style	charge
 read_data	data.FeOH3
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.Fe_O_C_H H O Fe
 
 neighbor	2 bin

--- a/public/examples/reaxff/RDX/RDX.in
+++ b/public/examples/reaxff/RDX/RDX.in
@@ -17,7 +17,7 @@ units		real
 atom_style	charge
 read_data	data.RDX
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.rdx H C O N
 
 neighbor	2 bin

--- a/public/examples/reaxff/VOH/VOH.in
+++ b/public/examples/reaxff/VOH/VOH.in
@@ -16,7 +16,7 @@ units		real
 atom_style	charge
 read_data	data.VOH
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.V_O_C_H H C O V
 
 neighbor	2 bin

--- a/public/examples/reaxff/ZnOH2/ZnOH2.in
+++ b/public/examples/reaxff/ZnOH2/ZnOH2.in
@@ -14,7 +14,7 @@ units		real
 atom_style	charge
 read_data	data.ZnOH2
 
-pair_style	reax/c lmp_control
+pair_style	reaxff lmp_control
 pair_coeff	* * ffield.reax.ZnOH H O Zn
 
 neighbor	2 bin

--- a/public/examples/reaxff/ssz_13/ssz_13.in
+++ b/public/examples/reaxff/ssz_13/ssz_13.in
@@ -15,9 +15,9 @@ atom_style charge
 read_data CHA_wAl.data
 replicate 2 2 2
 
-pair_style reax/c NULL 
+pair_style reaxff NULL 
 pair_coeff * * ffield_Psofogiannakis_CuOH_2015 Si Al O H
-fix qeq all qeq/reax 1 0.0 10.0 1e-4 reax/c
+fix qeq all qeq/reax 1 0.0 10.0 1e-4 reaxff
 neigh_modify every 1 delay 0 check yes
 
 timestep 0.25


### PR DESCRIPTION
## Description
This PR updates all ReaxFF example files to use the new `reaxff` pair style instead of the deprecated `reax/c` pair style.

## Changes
LAMMPS has renamed the pair style 'reax/c' to 'reaxff'. This updates all example files to prevent the error:
```
Pair style 'reax/c' has been renamed to 'reaxff'
```

### Updated files:
- `public/examples/reaxff/AB/AB.in`
- `public/examples/reaxff/CHO/CHO.in`
- `public/examples/reaxff/FeOH3/FeOH3.in`
- `public/examples/reaxff/RDX/RDX.in`
- `public/examples/reaxff/VOH/VOH.in`
- `public/examples/reaxff/ZnOH2/ZnOH2.in`
- `public/examples/reaxff/ssz_13/ssz_13.in` (including fix qeq parameter)

All instances of `pair_style reax/c` have been replaced with `pair_style reaxff`, and the `fix qeq` parameter in ssz_13 has also been updated.