### PR TITLE
feat: add typecheck to CI pipeline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,8 @@ jobs:
           node-version: "20.x"
       - name: Install Packages
         run: npm install
+      - name: Run Typecheck
+        run: npm run typecheck
       - name: Run Tests
         run: npm run test:run
       - name: Run Prettier

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
+    "typecheck": "tsc --noEmit",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"


### PR DESCRIPTION
Adds TypeScript typechecking to the CI pipeline to catch type errors before merging.

Changes:
- Added `typecheck` script to package.json: `tsc --noEmit`
- Added typecheck step to CI workflow after installing packages and before running tests

This ensures that all TypeScript code is type-checked as part of the CI process.