### PR TITLE
Skip loading default examples in embedded mode

### DIFF
--- a/src/containers/Examples.tsx
+++ b/src/containers/Examples.tsx
@@ -3,6 +3,7 @@ import { Select, Divider } from "antd";
 import { Simulation } from "../store/simulation";
 import { SimulationFile } from "../store/app";
 import { useStoreActions, useStoreState } from "../hooks";
+import { useEmbeddedMode } from "../hooks/useEmbeddedMode";
 import { CaretRightOutlined, EditOutlined } from "@ant-design/icons";
 import { Layout, Skeleton, notification } from "antd";
 import { track } from "../utils/metrics";
@@ -43,6 +44,7 @@ const Examples = () => {
   const setPreferredView = useStoreActions(
     (actions) => actions.app.setPreferredView,
   );
+  const { isEmbeddedMode } = useEmbeddedMode();
 
   useEffect(() => {
     const fetchExamples = async (examplesUrl: string) => {
@@ -74,6 +76,11 @@ const Examples = () => {
       const urlSearchParams = new URLSearchParams(window.location.search);
       const params = Object.fromEntries(urlSearchParams.entries());
 
+      // Skip loading default examples if in embedded mode and no explicit examplesUrl is provided
+      if (isEmbeddedMode && params["examplesUrl"] == null) {
+        return;
+      }
+
       let defaultExamplesUrl = "examples/examples.json";
       let examplesUrl = defaultExamplesUrl;
       if (params["examplesUrl"] != null) {
@@ -89,7 +96,7 @@ const Examples = () => {
         await fetchExamples(defaultExamplesUrl);
       }
     })();
-  }, []);
+  }, [isEmbeddedMode]);
 
   const onPlay = useCallback(
     (example: Example) => {


### PR DESCRIPTION
## Problem

When Atomify loads in embedded mode (via `embeddedSimulationUrl` parameter), it currently loads the default examples from `examples/examples.json` before loading the embedded simulation. This causes unnecessary bloat and slower initial load times.

## Solution

Modified `Examples.tsx` to check if we're in embedded mode and skip loading default examples when embedded.

## Changes

- Added `useEmbeddedMode` hook import
- Added check to skip loading default examples when:
  - `isEmbeddedMode` is `true` AND
  - No explicit `examplesUrl` parameter is provided
- Updated `useEffect` dependencies to include `isEmbeddedMode`

This allows explicit examples URLs to still work even in embedded mode, while skipping the unnecessary default examples load for typical embedded use cases.

## Testing

Tested that:
- Embedded mode with `embeddedSimulationUrl` skips loading default examples
- Explicit `examplesUrl` parameter still works in embedded mode
- Non-embedded mode continues to load default examples as before