### PR TITLE
fix: TypeScript error in WASM module type inference

### DIFF
--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -162,6 +162,7 @@ const SimulationComponent = () => {
         createModule({
           print: onPrint,
           printErr: onPrint,
+          // @ts-ignore - createModule returns AtomifyWasmModule but TypeScript infers {}
         }).then((Module) => {
           track("WASM.Load");
           setStatus({
@@ -170,7 +171,8 @@ const SimulationComponent = () => {
             progress: 0.6,
           });
           // setWasm(Module)
-          const lammps = new Module.LAMMPSWeb() as LammpsWeb;
+          // @ts-ignore - Module is AtomifyWasmModule
+          const lammps = new Module.LAMMPSWeb();
           setLammps(lammps);
           // @ts-ignore
           window.wasm = Module;


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error in Simulation.tsx where the WASM module type cannot be inferred from the .mjs file.

## Changes

- Added `@ts-ignore` comments with explanations for WASM module type issues
- Removed unnecessary type cast (`as LammpsWeb`)
- Follows existing pattern in codebase for handling WASM types

## Impact / Benefits

- Resolves TypeScript compilation errors
- Maintains runtime functionality (code already worked correctly)
- Uses consistent approach with rest of codebase

## Technical Details

The `createModule` function from `lammps.mjs` returns an `AtomifyWasmModule`, but TypeScript cannot infer this from the `.mjs` file and defaults to `{}`. This causes type errors when accessing `Module.LAMMPSWeb()`.

Rather than using type casts (which go against project conventions), we use `@ts-ignore` comments with clear explanations, consistent with how other WASM-related type issues are handled in the file (e.g., `window.wasm`, `window.lammps`).
