### PR TITLE
style: update color scheme from black to grey-ish tones

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,8 +36,8 @@ const darkThemeConfig = {
   token: {
     colorPrimary: '#1890ff',
     borderRadius: 8,
-    colorBgBase: '#0a0a0a',
-    colorBgContainer: '#141414',
+    colorBgBase: '#29282d',
+    colorBgContainer: '#2a292f',
     fontSizeHeading1: 48,
     fontSizeHeading2: 36,
   },
@@ -48,11 +48,11 @@ const darkThemeConfig = {
       itemMarginInline: 8,
     },
     Layout: {
-      siderBg: '#0a0a0a',
+      siderBg: '#29282d',
       triggerBg: '#1f1f1f',
     },
     Select: {
-      selectorBg: '#141414',
+      selectorBg: '#2a292f',
       optionSelectedBg: '#2a2a2a',
       colorText: '#ffffff',
       colorTextPlaceholder: '#888',

--- a/src/components/LoadingSimulationScreen.tsx
+++ b/src/components/LoadingSimulationScreen.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   justify-content: center;
   height: 100vh;
   color: #ffffff;
-  background-color: #0a0a0a;
+  background-color: #1a1b1f;
 `;
 
 const StatusText = styled.div`

--- a/src/containers/Examples.css
+++ b/src/containers/Examples.css
@@ -5,7 +5,7 @@
   transition: all 0.3s ease;
   border: 1px solid #3a3a3a;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
-  background: white;
+  background: #2a292f;
   cursor: pointer;
 }
 
@@ -17,7 +17,7 @@
 .card-image-container {
   position: relative;
   overflow: hidden;
-  background: #f8f9fa;
+  background: #1a1b1f;
 }
 
 .card-image {
@@ -83,7 +83,7 @@
 .card-title {
   font-size: 16px;
   font-weight: 600;
-  color: #1a1a1a;
+  color: #ffffff;
   margin-bottom: 8px;
   line-height: 1.3;
   display: -webkit-box;
@@ -94,7 +94,7 @@
 
 .card-description {
   font-size: 14px;
-  color: #666;
+  color: #d9d9d9;
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 4;
@@ -104,12 +104,12 @@
 }
 
 .card-description:hover {
-  color: #333;
+  color: #ffffff;
 }
 
 .card-author {
   font-size: 12px;
-  color: #888;
+  color: #b0b0b0;
   margin-top: 8px;
 }
 
@@ -134,7 +134,7 @@
   padding: 24px;
   margin: 0;
   min-height: 100%;
-  background: #000; /* Pure black background */
+  background: #1a1b1f; /* Grey-ish background */
   color: #ffffff; /* White text */
 }
 
@@ -162,7 +162,7 @@
 /* Note: Most styling is now handled via ConfigProvider Select theme in App.tsx */
 /* These styles remain as fallback for any edge cases */
 .examples-container .ant-select-selector {
-  background: #141414;
+  background: #2a292f;
   border-color: #3a3a3a;
   color: #ffffff;
 }
@@ -177,7 +177,7 @@
 }
 
 .site-layout-background.examples-header {
-  background: #000; /* Pure black header */
+  background: #1a1b1f; /* Grey-ish header */
   color: #ffffff; /* White text */
   padding: 0 24px;
   border-bottom: 1px solid #2a2a2a;

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,7 @@ body,
 
 /* Modern Sidebar Styling */
 .ant-layout-sider {
-  background: rgba(10, 10, 10, 0.85) !important;
+  background: rgba(41, 40, 45, 0.85) !important;
   backdrop-filter: blur(10px);
   border-right: 1px solid rgba(255, 255, 255, 0.05);
 }
@@ -71,7 +71,7 @@ body,
 }
 
 .ant-menu-dark .ant-menu-item-selected {
-  background-color: rgba(24, 144, 255, 0.2) !important;
+  background-color: rgb(42, 59, 80) !important;
   color: #40a9ff !important;
   font-weight: 600;
 }
@@ -82,7 +82,7 @@ body,
 }
 
 .site-layout .site-layout-background {
-  background: #000;
+  background: #1a1b1f;
   color: #fff;
 }
 
@@ -120,7 +120,7 @@ body,
 
 .simulationsummary {
   position: fixed !important;
-  background-color: rgba(10, 10, 10, 0.9);
+  background-color: rgba(26, 27, 31, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 10px;
   width: 300px;


### PR DESCRIPTION
## Changes

This PR updates the application's color scheme from pure black backgrounds to grey-ish tones for a softer, more modern appearance.

### Color Updates

- **Menu background**: Changed to rgb(41, 40, 45) - `#29282d`
- **Selected menu element**: Changed to rgb(42, 59, 80) - `#2a3b50`
- **Main page header**: Changed to rgb(26, 27, 31) - `#1a1b1f`
- **Card backgrounds**: Changed to rgb(42, 41, 47) - `#2a292f`

### Files Modified

- `src/index.css` - Updated sidebar, menu, and global backgrounds
- `src/App.tsx` - Updated Ant Design theme configuration
- `src/containers/Examples.css` - Updated Examples page and card styling
- `src/components/LoadingSimulationScreen.tsx` - Updated loading screen background

### Additional Updates

- Adjusted text colors throughout to ensure proper readability on the new grey backgrounds
- Updated card text colors (titles, descriptions) for better contrast
- Maintained consistency across all components