### PR TITLE
Update distance unit to LAMMPS setting

### DIFF
--- a/cpp/lammpsweb/lammpsweb.cpp
+++ b/cpp/lammpsweb/lammpsweb.cpp
@@ -366,6 +366,13 @@ std::string LAMMPSWeb::getLastCommand() {
   return lastCommand;
 }
 
+std::string LAMMPSWeb::getUnits() {
+  if (!m_lmp || !m_lmp->update) {
+    return "";
+  }
+  return std::string(m_lmp->update->unit_style);
+}
+
 
 int LAMMPSWeb::getTimesteps() {
   if (!m_lmp) {

--- a/cpp/lammpsweb/lammpsweb.h
+++ b/cpp/lammpsweb/lammpsweb.h
@@ -59,6 +59,7 @@ public:
   Fix getFix(std::string name);
   std::vector<std::string> getVariableNames();
   Variable getVariable(std::string name);
+  std::string getUnits();
   long getMemoryUsage();
   
   // Pointer getters
@@ -121,6 +122,7 @@ EMSCRIPTEN_BINDINGS(LAMMPSWeb)
     .function("getFixNames", &LAMMPSWeb::getFixNames)
     .function("getVariable", &LAMMPSWeb::getVariable)
     .function("getVariableNames", &LAMMPSWeb::getVariableNames)
+    .function("getUnits", &LAMMPSWeb::getUnits)
     .function("syncComputes", &LAMMPSWeb::syncComputes)
     .function("syncFixes", &LAMMPSWeb::syncFixes)
     .function("syncVariables", &LAMMPSWeb::syncVariables)

--- a/src/components/SelectedAtomsInfo.tsx
+++ b/src/components/SelectedAtomsInfo.tsx
@@ -1,6 +1,8 @@
 import { Button } from "antd";
 import { Particles } from "omovi";
 import { useMemo } from "react";
+import { useStoreState } from "../hooks";
+import { parseLammpsUnits, getDistanceUnitSymbol } from "../utils/parsers";
 
 interface SelectedAtomsInfoProps {
   selectedAtoms: Set<number>;
@@ -48,6 +50,26 @@ const SelectedAtomsInfo = ({
   particles,
   onClearSelection,
 }: SelectedAtomsInfoProps) => {
+  const simulation = useStoreState((state) => state.simulation.simulation);
+  
+  // Get the distance unit symbol based on LAMMPS unit system
+  const distanceUnit = useMemo(() => {
+    if (!simulation) {
+      return "Å"; // Default to Angstroms
+    }
+    
+    const inputScriptFile = simulation.files.find(
+      (file) => file.fileName === simulation.inputScript
+    );
+    
+    if (!inputScriptFile?.content) {
+      return "Å"; // Default to Angstroms
+    }
+    
+    const unitStyle = parseLammpsUnits(inputScriptFile.content);
+    return getDistanceUnitSymbol(unitStyle);
+  }, [simulation]);
+
   if (selectedAtoms.size === 0) {
     return null;
   }
@@ -117,7 +139,7 @@ const SelectedAtomsInfo = ({
             Geometry
           </div>
           <div style={{ fontFamily: "monospace", fontSize: "11px" }}>
-            Distance: {calculateDistance(atomData[0].position, atomData[1].position).toFixed(3)} Å
+            Distance: {calculateDistance(atomData[0].position, atomData[1].position).toFixed(3)} {distanceUnit}
           </div>
         </div>
       )}
@@ -130,15 +152,15 @@ const SelectedAtomsInfo = ({
           </div>
           <div style={{ fontFamily: "monospace", fontSize: "11px" }}>
             d({atomData[0].atomId}-{atomData[1].atomId}):{" "}
-            {calculateDistance(atomData[0].position, atomData[1].position).toFixed(3)} Å
+            {calculateDistance(atomData[0].position, atomData[1].position).toFixed(3)} {distanceUnit}
           </div>
           <div style={{ fontFamily: "monospace", fontSize: "11px" }}>
             d({atomData[1].atomId}-{atomData[2].atomId}):{" "}
-            {calculateDistance(atomData[1].position, atomData[2].position).toFixed(3)} Å
+            {calculateDistance(atomData[1].position, atomData[2].position).toFixed(3)} {distanceUnit}
           </div>
           <div style={{ fontFamily: "monospace", fontSize: "11px" }}>
             d({atomData[0].atomId}-{atomData[2].atomId}):{" "}
-            {calculateDistance(atomData[0].position, atomData[2].position).toFixed(3)} Å
+            {calculateDistance(atomData[0].position, atomData[2].position).toFixed(3)} {distanceUnit}
           </div>
           <div style={{ marginTop: "5px" }}>
             <div style={{ fontFamily: "monospace", fontSize: "11px" }}>

--- a/src/components/SelectedAtomsInfo.tsx
+++ b/src/components/SelectedAtomsInfo.tsx
@@ -1,8 +1,7 @@
 import { Button } from "antd";
 import { Particles } from "omovi";
 import { useMemo } from "react";
-import { useStoreState } from "../hooks";
-import { parseLammpsUnits, getDistanceUnitSymbol } from "../utils/parsers";
+import { useLammpsUnits } from "../hooks/useLammpsUnits";
 
 interface SelectedAtomsInfoProps {
   selectedAtoms: Set<number>;
@@ -50,25 +49,7 @@ const SelectedAtomsInfo = ({
   particles,
   onClearSelection,
 }: SelectedAtomsInfoProps) => {
-  const simulation = useStoreState((state) => state.simulation.simulation);
-  
-  // Get the distance unit symbol based on LAMMPS unit system
-  const distanceUnit = useMemo(() => {
-    if (!simulation) {
-      return "Å"; // Default to Angstroms
-    }
-    
-    const inputScriptFile = simulation.files.find(
-      (file) => file.fileName === simulation.inputScript
-    );
-    
-    if (!inputScriptFile?.content) {
-      return "Å"; // Default to Angstroms
-    }
-    
-    const unitStyle = parseLammpsUnits(inputScriptFile.content);
-    return getDistanceUnitSymbol(unitStyle);
-  }, [simulation]);
+  const distanceUnit = useLammpsUnits();
 
   if (selectedAtoms.size === 0) {
     return null;

--- a/src/hooks/useLammpsUnits.ts
+++ b/src/hooks/useLammpsUnits.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+import { useStoreState } from "./index";
+import { getDistanceUnitSymbol } from "../utils/parsers";
+
+/**
+ * Hook to get the distance unit symbol based on the current LAMMPS unit system
+ * @returns The distance unit symbol (e.g., "Å", "σ", "m", "cm", etc.)
+ */
+export const useLammpsUnits = (): string => {
+  const lammps = useStoreState((state) => state.simulation.lammps);
+
+  return useMemo(() => {
+    if (!lammps) {
+      return "Å"; // Default to Angstroms if LAMMPS is not available
+    }
+
+    const unitStyle = lammps.getUnits();
+    return getDistanceUnitSymbol(unitStyle);
+  }, [lammps]);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type LammpsWeb = {
   getFixNames: () => CPPArray<string>;
   getVariable: (name: string) => LMPModifier;
   getVariableNames: () => CPPArray<string>;
+  getUnits: () => string;
   syncComputes: () => void;
   syncFixes: () => void;
   syncVariables: () => void;

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -89,26 +89,6 @@ export const parseAtomSizeAndColor = (line: string) => {
 };
 
 /**
- * Parses LAMMPS units command from input script
- * @param inputScript The LAMMPS input script content
- * @returns The unit style string (e.g., "real", "metal", "lj", "si", etc.) or undefined if not found
- */
-export const parseLammpsUnits = (inputScript: string): string | undefined => {
-  const lines = inputScript.split("\n");
-  for (const line of lines) {
-    // Remove comments (everything after #)
-    const withoutComments = line.split("#")[0];
-    const trimmed = withoutComments.trim();
-    // Match "units <style>" command
-    const match = trimmed.match(/^units\s+(\w+)/i);
-    if (match) {
-      return match[1].toLowerCase();
-    }
-  }
-  return undefined;
-};
-
-/**
  * Gets the distance unit symbol for a given LAMMPS unit style
  * @param unitStyle The LAMMPS unit style (e.g., "real", "metal", "lj", "si", etc.)
  * @returns The distance unit symbol string

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -88,3 +88,55 @@ export const parseAtomSizeAndColor = (line: string) => {
   }
 };
 
+/**
+ * Parses LAMMPS units command from input script
+ * @param inputScript The LAMMPS input script content
+ * @returns The unit style string (e.g., "real", "metal", "lj", "si", etc.) or undefined if not found
+ */
+export const parseLammpsUnits = (inputScript: string): string | undefined => {
+  const lines = inputScript.split("\n");
+  for (const line of lines) {
+    // Remove comments (everything after #)
+    const withoutComments = line.split("#")[0];
+    const trimmed = withoutComments.trim();
+    // Match "units <style>" command
+    const match = trimmed.match(/^units\s+(\w+)/i);
+    if (match) {
+      return match[1].toLowerCase();
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Gets the distance unit symbol for a given LAMMPS unit style
+ * @param unitStyle The LAMMPS unit style (e.g., "real", "metal", "lj", "si", etc.)
+ * @returns The distance unit symbol string
+ */
+export const getDistanceUnitSymbol = (unitStyle: string | undefined): string => {
+  if (!unitStyle) {
+    return "Å"; // Default to Angstroms if unit style is not found
+  }
+  
+  const style = unitStyle.toLowerCase();
+  switch (style) {
+    case "lj":
+      return "σ";
+    case "real":
+    case "metal":
+      return "Å";
+    case "si":
+      return "m";
+    case "cgs":
+      return "cm";
+    case "electron":
+      return "a₀";
+    case "micro":
+      return "μm";
+    case "nano":
+      return "nm";
+    default:
+      return "Å"; // Default to Angstroms for unknown unit styles
+  }
+};
+


### PR DESCRIPTION
Dynamically display distance units in SelectedAtomsInfo based on the LAMMPS input script's unit system.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7286c96-90ab-46db-8b65-c91c9047d8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7286c96-90ab-46db-8b65-c91c9047d8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

