### PR TITLE
Disable file editing while running simulation

### DIFF
--- a/src/containers/Edit.test.tsx
+++ b/src/containers/Edit.test.tsx
@@ -89,36 +89,7 @@ describe('Edit', () => {
 
   it('should render "No file selected" when no file is selected', () => {
     // Arrange
-    store = createStore({
-      app: {
-        selectedFile: undefined,
-        setSelectedFile: vi.fn(),
-        setStatus: vi.fn(),
-      },
-      simulation: {
-        running: false,
-        paused: false,
-        showConsole: false,
-        files: [],
-        lammpsOutput: [],
-        resetLammpsOutput: vi.fn(),
-        addLammpsOutput: vi.fn(),
-        setShowConsole: vi.fn(),
-        setPaused: vi.fn(),
-        setCameraPosition: vi.fn(),
-        setCameraTarget: vi.fn(),
-        setSimulation: vi.fn(),
-        setRunning: vi.fn(),
-        setFiles: vi.fn(),
-        setLammps: vi.fn(),
-        extractAndApplyAtomifyCommands: vi.fn(),
-        syncFilesWasm: vi.fn(),
-        syncFilesJupyterLite: vi.fn(),
-        run: vi.fn(),
-        newSimulation: vi.fn(),
-        reset: vi.fn(),
-      },
-    } as any);
+    store.getState().app.selectedFile = undefined;
 
     // Act
     render(

--- a/src/containers/Edit.test.tsx
+++ b/src/containers/Edit.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@monaco-editor/react', () => ({
 }));
 
 describe('Edit', () => {
-  let store: ReturnType<typeof createStore<StoreModel>>;
+  let store: any;
 
   beforeEach(() => {
     // Create a minimal store with the necessary state
@@ -89,7 +89,7 @@ describe('Edit', () => {
 
   it('should render "No file selected" when no file is selected', () => {
     // Arrange
-    store = createStore<Partial<StoreModel>>({
+    store = createStore({
       app: {
         selectedFile: undefined,
         setSelectedFile: vi.fn(),

--- a/src/containers/Edit.test.tsx
+++ b/src/containers/Edit.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StoreProvider, createStore } from 'easy-peasy';
+import Edit from './Edit';
+import { StoreModel } from '../store/model';
+
+// Mock Monaco Editor
+vi.mock('@monaco-editor/react', () => ({
+  default: vi.fn(({ options, value }) => (
+    <div data-testid="monaco-editor" data-readonly={options.readOnly}>
+      {value}
+    </div>
+  )),
+  loader: {
+    init: vi.fn(() => Promise.resolve({
+      languages: {
+        register: vi.fn(),
+        setMonarchTokensProvider: vi.fn(),
+      },
+    })),
+  },
+}));
+
+describe('Edit', () => {
+  let store: ReturnType<typeof createStore<StoreModel>>;
+
+  beforeEach(() => {
+    // Create a minimal store with the necessary state
+    store = createStore<Partial<StoreModel>>({
+      app: {
+        selectedFile: {
+          fileName: 'test.in',
+          content: 'units lj\natom_style atomic',
+          url: '',
+        },
+        setSelectedFile: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      simulation: {
+        running: false,
+        paused: false,
+        showConsole: false,
+        files: [],
+        lammpsOutput: [],
+        simulation: {
+          id: 'test-sim',
+          files: [
+            {
+              fileName: 'test.in',
+              content: 'units lj\natom_style atomic',
+              url: '',
+            },
+          ],
+          inputScript: 'test.in',
+          start: false,
+        },
+        resetLammpsOutput: vi.fn(),
+        addLammpsOutput: vi.fn(),
+        setShowConsole: vi.fn(),
+        setPaused: vi.fn(),
+        setCameraPosition: vi.fn(),
+        setCameraTarget: vi.fn(),
+        setSimulation: vi.fn(),
+        setRunning: vi.fn(),
+        setFiles: vi.fn(),
+        setLammps: vi.fn(),
+        extractAndApplyAtomifyCommands: vi.fn(),
+        syncFilesWasm: vi.fn(),
+        syncFilesJupyterLite: vi.fn(),
+        run: vi.fn(),
+        newSimulation: vi.fn(),
+        reset: vi.fn(),
+      },
+    } as any);
+  });
+
+  it('should render editor when file is selected', () => {
+    // Arrange & Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('monaco-editor')).toHaveTextContent('units lj');
+  });
+
+  it('should render "No file selected" when no file is selected', () => {
+    // Arrange
+    store = createStore<Partial<StoreModel>>({
+      app: {
+        selectedFile: undefined,
+        setSelectedFile: vi.fn(),
+        setStatus: vi.fn(),
+      },
+      simulation: {
+        running: false,
+        paused: false,
+        showConsole: false,
+        files: [],
+        lammpsOutput: [],
+        resetLammpsOutput: vi.fn(),
+        addLammpsOutput: vi.fn(),
+        setShowConsole: vi.fn(),
+        setPaused: vi.fn(),
+        setCameraPosition: vi.fn(),
+        setCameraTarget: vi.fn(),
+        setSimulation: vi.fn(),
+        setRunning: vi.fn(),
+        setFiles: vi.fn(),
+        setLammps: vi.fn(),
+        extractAndApplyAtomifyCommands: vi.fn(),
+        syncFilesWasm: vi.fn(),
+        syncFilesJupyterLite: vi.fn(),
+        run: vi.fn(),
+        newSimulation: vi.fn(),
+        reset: vi.fn(),
+      },
+    } as any);
+
+    // Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    expect(screen.getByText('No file selected')).toBeInTheDocument();
+    expect(screen.queryByTestId('monaco-editor')).not.toBeInTheDocument();
+  });
+
+  it('should be editable when simulation is not running', () => {
+    // Arrange
+    store.getState().simulation.running = false;
+
+    // Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    const editor = screen.getByTestId('monaco-editor');
+    expect(editor).toHaveAttribute('data-readonly', 'false');
+  });
+
+  it('should be read-only when simulation is running', () => {
+    // Arrange
+    store.getState().simulation.running = true;
+
+    // Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    const editor = screen.getByTestId('monaco-editor');
+    expect(editor).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('should show notification banner when simulation is running', () => {
+    // Arrange
+    store.getState().simulation.running = true;
+
+    // Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    expect(screen.getByText(/File editing is disabled while simulation is running/i)).toBeInTheDocument();
+  });
+
+  it('should not show notification banner when simulation is not running', () => {
+    // Arrange
+    store.getState().simulation.running = false;
+
+    // Act
+    render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    expect(screen.queryByText(/File editing is disabled while simulation is running/i)).not.toBeInTheDocument();
+  });
+
+  it('should update content when file content changes', () => {
+    // Arrange
+    const { rerender } = render(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Act - Update the selected file content
+    store.getState().app.selectedFile = {
+      fileName: 'test.in',
+      content: 'units metal\natom_style full',
+      url: '',
+    };
+
+    rerender(
+      <StoreProvider store={store}>
+        <Edit />
+      </StoreProvider>
+    );
+
+    // Assert
+    expect(screen.getByTestId('monaco-editor')).toHaveTextContent('units metal');
+  });
+});

--- a/src/containers/Edit.tsx
+++ b/src/containers/Edit.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import type { CSSProperties } from "react";
 import { useStoreState } from "../hooks";
 import Editor, { loader } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
@@ -8,6 +9,26 @@ import { registerLammpsLanguage } from "../utils/lammpsLanguage";
 loader.init().then((monaco) => {
   registerLammpsLanguage(monaco);
 });
+
+const bannerStyle: CSSProperties = {
+  backgroundColor: "#3a3a3a",
+  color: "#ffa500",
+  padding: "8px 16px",
+  fontSize: "12px",
+  borderBottom: "1px solid #555",
+  fontFamily: "monospace",
+};
+
+const containerStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100vh",
+};
+
+const editorWrapperStyle: CSSProperties = {
+  flex: 1,
+  position: "relative",
+};
 
 const Edit = () => {
   const selectedFile = useStoreState((state) => state.app.selectedFile);
@@ -43,31 +64,24 @@ const Edit = () => {
   }
 
   return (
-    <>
+    <div style={containerStyle}>
       {isRunning && (
-        <div
-          style={{
-            backgroundColor: "#3a3a3a",
-            color: "#ffa500",
-            padding: "8px 16px",
-            fontSize: "12px",
-            borderBottom: "1px solid #555",
-            fontFamily: "monospace",
-          }}
-        >
+        <div style={bannerStyle}>
           ⓘ File editing is disabled while simulation is running
         </div>
       )}
-      <Editor
-        height={isRunning ? "calc(100vh - 33px)" : "100vh"}
-        language="lammps"
-        theme="vs-dark"
-        value={selectedFile.content}
-        options={options}
-        onChange={onEditorChange}
-        onMount={handleEditorDidMount}
-      />
-    </>
+      <div style={editorWrapperStyle}>
+        <Editor
+          height="100%"
+          language="lammps"
+          theme="vs-dark"
+          value={selectedFile.content}
+          options={options}
+          onChange={onEditorChange}
+          onMount={handleEditorDidMount}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/src/containers/Edit.tsx
+++ b/src/containers/Edit.tsx
@@ -12,8 +12,10 @@ loader.init().then((monaco) => {
 const Edit = () => {
   const selectedFile = useStoreState((state) => state.app.selectedFile);
   const simulation = useStoreState((state) => state.simulation.simulation);
+  const isRunning = useStoreState((state) => state.simulation.running);
   const options = {
     selectOnLineNumbers: true,
+    readOnly: isRunning,
   };
 
   const handleEditorDidMount = useCallback(
@@ -41,15 +43,31 @@ const Edit = () => {
   }
 
   return (
-    <Editor
-      height="100vh"
-      language="lammps"
-      theme="vs-dark"
-      value={selectedFile.content}
-      options={options}
-      onChange={onEditorChange}
-      onMount={handleEditorDidMount}
-    />
+    <>
+      {isRunning && (
+        <div
+          style={{
+            backgroundColor: "#3a3a3a",
+            color: "#ffa500",
+            padding: "8px 16px",
+            fontSize: "12px",
+            borderBottom: "1px solid #555",
+            fontFamily: "monospace",
+          }}
+        >
+          ⓘ File editing is disabled while simulation is running
+        </div>
+      )}
+      <Editor
+        height={isRunning ? "calc(100vh - 33px)" : "100vh"}
+        language="lammps"
+        theme="vs-dark"
+        value={selectedFile.content}
+        options={options}
+        onChange={onEditorChange}
+        onMount={handleEditorDidMount}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Disable file editing in the Monaco editor when a simulation is running to prevent conflicts and inform the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bada9f0-a618-43e7-af26-ec979fad9720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bada9f0-a618-43e7-af26-ec979fad9720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

