### PR TITLE
Disable notebook button during simulation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const NOTEBOOK_DISABLED_TOOLTIP =
+  "Can only analyze in Jupyter notebook after simulation has finished";

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -1,4 +1,5 @@
-import { Modal, Tabs, Progress, Button, Layout } from "antd";
+import { Modal, Tabs, Progress, Button, Layout, Tooltip } from "antd";
+import { NOTEBOOK_DISABLED_TOOLTIP } from "../constants";
 import { useState, useEffect, useMemo } from "react";
 import View from "./View";
 import Notebook from "./Notebook";
@@ -21,6 +22,8 @@ const Main = ({ isEmbedded }: { isEmbedded: boolean }) => {
   );
   const selectedMenu = useStoreState((state) => state.app.selectedMenu);
   const running = useStoreState((state) => state.simulation.running);
+  const paused = useStoreState((state) => state.simulation.paused);
+  const isSimulationActive = running || paused;
 
   const setPreferredView = useStoreActions(
     (actions) => actions.app.setPreferredView,
@@ -103,15 +106,21 @@ const Main = ({ isEmbedded }: { isEmbedded: boolean }) => {
           styles={{ body: { backgroundColor: "#1E1E1E" } }}
           width={"80%"}
           footer={[
-            <Button
-              key="analyze"
-              onClick={() => {
-                setShowConsole(false);
-                setPreferredView("notebook");
-              }}
+            <Tooltip
+              key="analyze-tooltip"
+              title={isSimulationActive ? NOTEBOOK_DISABLED_TOOLTIP : ""}
             >
-              Analyze in notebook
-            </Button>,
+              <Button
+                key="analyze"
+                disabled={isSimulationActive}
+                onClick={() => {
+                  setShowConsole(false);
+                  setPreferredView("notebook");
+                }}
+              >
+                Analyze in notebook
+              </Button>
+            </Tooltip>,
             <Button key="close" onClick={() => setShowConsole(false)}>
               Close
             </Button>,

--- a/src/hooks/useMenuItems.tsx
+++ b/src/hooks/useMenuItems.tsx
@@ -18,6 +18,7 @@ import React from "react";
 import type { MenuProps } from "antd";
 import { Badge } from "antd";
 import { useStoreActions, useStoreState } from "./index";
+import { NOTEBOOK_DISABLED_TOOLTIP } from "../constants";
 import { track } from "../utils/metrics";
 import { setCancel } from "../wasm/wasmInstance";
 
@@ -30,6 +31,7 @@ function getItem(
   children?: MenuItem[],
   onClick?: () => void,
   disabled?: boolean,
+  title?: string,
 ): MenuItem {
   return {
     key,
@@ -38,6 +40,7 @@ function getItem(
     label,
     onClick,
     disabled,
+    title,
   } as MenuItem;
 }
 
@@ -52,6 +55,7 @@ export function useMenuItems(callbacks: UseMenuItemsCallbacks): MenuItem[] {
   const simulation = useStoreState((state) => state.simulation.simulation);
   const selectedFile = useStoreState((state) => state.app.selectedFile);
   const paused = useStoreState((state) => state.simulation.paused);
+  const isSimulationActive = running || paused;
   const selectedMenu = useStoreState((state) => state.app.selectedMenu);
   const setPaused = useStoreActions((actions) => actions.simulation.setPaused);
   const setPreferredView = useStoreActions(
@@ -138,7 +142,15 @@ export function useMenuItems(callbacks: UseMenuItemsCallbacks): MenuItem[] {
   return [
     getItem("View", "view", <AlignLeftOutlined />),
     getItem("Console", "console", <BorderOuterOutlined />),
-    getItem("Notebook", "notebook", <LineChartOutlined />),
+    getItem(
+      "Notebook",
+      "notebook",
+      <LineChartOutlined />,
+      undefined,
+      undefined,
+      isSimulationActive,
+      isSimulationActive ? NOTEBOOK_DISABLED_TOOLTIP : undefined,
+    ),
     getItem(
       editMenuLabel,
       "edit",


### PR DESCRIPTION
Disable the "Notebook" menu item and "Analyze in notebook" button while the simulation is running or paused to prevent errors, providing a tooltip with the reason.

---
<a href="https://cursor.com/background-agent?bcId=bc-41adae57-5578-4d49-92b6-05396d96ec8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41adae57-5578-4d49-92b6-05396d96ec8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

