### PR TITLE
Check and fix particle tag consistency in lammps

### DIFF
--- a/cpp/lammpsweb/lammpsweb.cpp
+++ b/cpp/lammpsweb/lammpsweb.cpp
@@ -575,7 +575,7 @@ long LAMMPSWeb::getPositionsPointer() {
 }
 
 long LAMMPSWeb::getIdPointer() {
-  auto ptr = lammps_extract_atom((void *)m_lmp, "id");
+  auto ptr = lammps_extract_atom((void *)m_lmp, "tag");
 
   return reinterpret_cast<long>(ptr);
 }

--- a/cpp/lammpsweb/lammpsweb.cpp
+++ b/cpp/lammpsweb/lammpsweb.cpp
@@ -575,7 +575,18 @@ long LAMMPSWeb::getPositionsPointer() {
 }
 
 long LAMMPSWeb::getIdPointer() {
+  auto ptr = lammps_extract_atom((void *)m_lmp, "id");
+
+  return reinterpret_cast<long>(ptr);
+}
+
+long LAMMPSWeb::getTagPointer() {
   auto ptr = lammps_extract_atom((void *)m_lmp, "tag");
+  
+  // Tag may not exist for all atom styles, return 0 if not available
+  if (!ptr) {
+    return 0;
+  }
 
   return reinterpret_cast<long>(ptr);
 }

--- a/cpp/lammpsweb/lammpsweb.h
+++ b/cpp/lammpsweb/lammpsweb.h
@@ -65,6 +65,7 @@ public:
   long getBondsDistanceMapPointer();
   long getPositionsPointer();
   long getIdPointer();
+  long getTagPointer();
   long getTypePointer();
   long getBondsPosition1Pointer();
   long getBondsPosition2Pointer();
@@ -129,6 +130,7 @@ EMSCRIPTEN_BINDINGS(LAMMPSWeb)
     .function("getPositionsPointer", &LAMMPSWeb::getPositionsPointer)
     .function("getBondsDistanceMapPointer", &LAMMPSWeb::getBondsDistanceMapPointer)
     .function("getIdPointer", &LAMMPSWeb::getIdPointer)
+    .function("getTagPointer", &LAMMPSWeb::getTagPointer)
     .function("getTypePointer", &LAMMPSWeb::getTypePointer)
     .function("getCellMatrixPointer", &LAMMPSWeb::getCellMatrixPointer)
     .function("getOrigoPointer", &LAMMPSWeb::getOrigoPointer)

--- a/src/modifiers/syncparticlesmodifier.ts
+++ b/src/modifiers/syncparticlesmodifier.ts
@@ -48,7 +48,12 @@ class SyncParticlesModifier extends Modifier {
 
     const positionsPtr = input.lammps.getPositionsPointer() / 4;
     const typePtr = input.lammps.getTypePointer() / 4;
-    const idPtr = input.lammps.getIdPointer() / 4;
+
+    // Try to use tag first (persistent particle identifier), fallback to id if not available
+    const tagPtr = input.lammps.getTagPointer();
+    const particleIdPtr =
+      tagPtr !== 0 ? tagPtr / 4 : input.lammps.getIdPointer() / 4;
+
     const positionsSubarray = input.wasm.HEAPF32.subarray(
       positionsPtr,
       positionsPtr + 3 * numParticles,
@@ -58,8 +63,8 @@ class SyncParticlesModifier extends Modifier {
       typePtr + numParticles,
     ) as Int32Array;
     const idSubarray = input.wasm.HEAP32.subarray(
-      idPtr,
-      idPtr + numParticles,
+      particleIdPtr,
+      particleIdPtr + numParticles,
     ) as Int32Array;
 
     newParticles.positions.set(positionsSubarray);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type LammpsWeb = {
 
   getPositionsPointer: () => number;
   getIdPointer: () => number;
+  getTagPointer: () => number;
   getTypePointer: () => number;
   getCellMatrixPointer: () => number;
   getOrigoPointer: () => number;


### PR DESCRIPTION
Use LAMMPS "tag" field for particle identification instead of "id" to ensure consistent tracking across simulation steps.

The "tag" field in LAMMPS provides a persistent unique identifier for particles, which is crucial for reliable tracking over time. The "id" field, while also an identifier, may not be as consistent for this purpose.

---
<a href="https://cursor.com/background-agent?bcId=bc-706d4159-4d71-4b2c-a7d9-cc7acbbbfe67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-706d4159-4d71-4b2c-a7d9-cc7acbbbfe67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

