### PR TITLE
Implement continuous simulation loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,7 @@ const App: React.FC = () => {
   const [showNewSimulation, setShowNewSimulation] = useState(false);
   const [showShareSimulation, setShowShareSimulation] = useState(false);
   const running = useStoreState((state) => state.simulation.running);
+  const finished = useStoreState((state) => state.simulation.finished);
   const simulation = useStoreState((state) => state.simulation.simulation);
   const selectedFile = useStoreState((state) => state.app.selectedFile);
   const setSelectedFile = useStoreActions(
@@ -102,6 +103,7 @@ const App: React.FC = () => {
   const selectedMenu = useStoreState((state) => state.app.selectedMenu);
 
   const run = useStoreActions((actions) => actions.simulation.run);
+  const continueSimulation = useStoreActions((actions) => actions.simulation.continueSimulation);
 
   const { isEmbeddedMode } = useEmbeddedMode();
 
@@ -145,6 +147,18 @@ const App: React.FC = () => {
       setPreferredView(selectedMenu); // This is another hack. Should really rethink menu system.
     },
     running === false,
+  );
+
+  const continueButton = getItem(
+    "Continue simulation",
+    "continue",
+    <CaretRightOutlined />,
+    undefined,
+    () => {
+      continueSimulation(undefined);
+      setPreferredView("view");
+    },
+    !finished || running,
   );
 
   const newSimulationButton = getItem(
@@ -208,6 +222,7 @@ const App: React.FC = () => {
       simulation == null,
     ),
     pauseButton,
+    continueButton,
   ];
 
   useEffect(() => {

--- a/src/store/simulation.test.ts
+++ b/src/store/simulation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { action, createStore } from 'easy-peasy';
+import type { SimulationModel, Simulation } from './simulation';
+import type { LammpsWeb } from '../types';
+
+describe('SimulationModel', () => {
+  describe('finished state', () => {
+    it('should initialize with finished as false', () => {
+      // Arrange
+      const store = createStore<Pick<SimulationModel, 'finished' | 'setFinished'>>({
+        finished: false,
+        setFinished: action((state, value: boolean) => {
+          state.finished = value;
+        }),
+      });
+
+      // Act
+      const state = store.getState();
+
+      // Assert
+      expect(state.finished).toBe(false);
+    });
+
+    it('should set finished state to true', () => {
+      // Arrange
+      const store = createStore<Pick<SimulationModel, 'finished' | 'setFinished'>>({
+        finished: false,
+        setFinished: action((state, value: boolean) => {
+          state.finished = value;
+        }),
+      });
+
+      // Act
+      store.getActions().setFinished(true);
+
+      // Assert
+      expect(store.getState().finished).toBe(true);
+    });
+
+    it('should set finished state to false', () => {
+      // Arrange
+      const store = createStore<Pick<SimulationModel, 'finished' | 'setFinished'>>({
+        finished: true,
+        setFinished: action((state, value: boolean) => {
+          state.finished = value;
+        }),
+      });
+
+      // Act
+      store.getActions().setFinished(false);
+
+      // Assert
+      expect(store.getState().finished).toBe(false);
+    });
+
+    it('should reset finished state on reset action', () => {
+      // Arrange
+      const store = createStore<Pick<SimulationModel, 'finished' | 'files' | 'lammps' | 'reset'>>({
+        finished: true,
+        files: ['test.in'],
+        lammps: undefined,
+        reset: action((state) => {
+          state.files = [];
+          state.lammps = undefined;
+          state.finished = false;
+        }),
+      });
+
+      // Act
+      store.getActions().reset(undefined);
+
+      // Assert
+      expect(store.getState().finished).toBe(false);
+      expect(store.getState().files).toEqual([]);
+    });
+  });
+
+  describe('continueSimulation types', () => {
+    it('should accept undefined timesteps parameter', () => {
+      // This test verifies that the type signature allows undefined
+      // The actual thunk implementation is tested through integration tests
+      
+      // Arrange
+      type ContinueSimulationAction = (timesteps: number | undefined) => void;
+      
+      // Act & Assert - This should compile without errors
+      const mockAction: ContinueSimulationAction = (timesteps) => {
+        if (timesteps === undefined) {
+          // Default behavior
+        } else {
+          // Custom timesteps
+        }
+      };
+      
+      // Verify both call signatures work
+      mockAction(1000);
+      mockAction(undefined);
+      
+      expect(mockAction).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Add the ability to continue a simulation after it finishes to allow users to run additional timesteps.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccb56570-1e96-441e-b8fa-c9556d3025c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ccb56570-1e96-441e-b8fa-c9556d3025c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

