### PR TITLE
Review and remove ts ignore on wasm object

### DIFF
--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -7,7 +7,6 @@ import { notification } from "antd";
 import { time_event, track } from "../utils/metrics";
 
 const SimulationComponent = () => {
-  // @ts-ignore
   const wasm = window.wasm;
   const lammps = useStoreState((state) => state.simulation.lammps);
   const simulation = useStoreState((state) => state.simulation.simulation);
@@ -150,7 +149,6 @@ const SimulationComponent = () => {
   ]);
 
   useEffect(() => {
-    // @ts-ignore
     if (!window.wasm) {
       setStatus({
         title: "Downloading LAMMPS ...",
@@ -178,7 +176,6 @@ const SimulationComponent = () => {
           // setWasm(Module)
           const lammps = new Module.LAMMPSWeb();
           setLammps(lammps);
-          // @ts-ignore
           window.wasm = Module;
           // @ts-ignore
           window.lammps = lammps;

--- a/src/containers/Main.tsx
+++ b/src/containers/Main.tsx
@@ -11,7 +11,6 @@ import { useStoreActions, useStoreState } from "../hooks";
 const { Content } = Layout;
 
 const Main = ({ isEmbedded }: { isEmbedded: boolean }) => {
-  // @ts-ignore
   const wasm = window.wasm; // TODO: This is an ugly hack because wasm object is so big that Redux debugger hangs.
   const showConsole = useStoreState((state) => state.simulation.showConsole);
   const [consoleKey, setConsoleKey] = useState(0);

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -106,7 +106,6 @@ export const simulationModel: SimulationModel = {
     (actions, inputScript: string, { getStoreActions, getStoreState }) => {
       const lines = inputScript.split("\n");
 
-      // @ts-ignore
       const wasm = window.wasm;
       // @ts-ignore
       const lammps = getStoreState().simulation.lammps;
@@ -184,7 +183,6 @@ export const simulationModel: SimulationModel = {
         return;
       }
 
-      // @ts-ignore
       const wasm = window.wasm;
       for (const file of simulation.files) {
         // Update all files if no fileName is specified
@@ -202,7 +200,6 @@ export const simulationModel: SimulationModel = {
       if (!simulation) {
         return;
       }
-      // @ts-ignore
       const wasm = window.wasm;
       const fileNames: string[] = wasm.FS.readdir(`/${simulation.id}`);
       const files: { [key: string]: SimulationFile } = {};
@@ -342,7 +339,7 @@ export const simulationModel: SimulationModel = {
         .map(([name, value]) => `variable ${name} equal ${value}`)
         .join('\n') + '\n\n';
       
-      const wasm = (window as any).wasm;
+      const wasm = window.wasm;
       const varsFileName = `_vars_${simulation.inputScript}`;
       wasm.FS.writeFile(`/${simulation.id}/${varsFileName}`, varsScript);
       
@@ -450,7 +447,6 @@ export const simulationModel: SimulationModel = {
       // @ts-ignore
       getStoreActions().render.resetParticleStyles();
 
-      // @ts-ignore
       const wasm = window.wasm;
       // @ts-ignore
       const lammps = getStoreState().simulation.lammps;


### PR DESCRIPTION
Remove unnecessary `@ts-ignore` comments for `window.wasm` as it is now correctly typed in `global.d.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec2daa47-d61d-4384-8122-f75aae88c5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec2daa47-d61d-4384-8122-f75aae88c5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

