### PR TITLE
feat: enable local network access for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     outDir: 'dist',
   },
   server: {
+    host: true, // Allow access from local network (0.0.0.0)
     port: 3000,
     proxy: {
       '/chapters': {


### PR DESCRIPTION
Adds `host: true` to Vite server config to allow access from local network (0.0.0.0). This enables testing on mobile devices and other devices on the same network.