### PR TITLE
chore(deps): bump JupyterLite to 0.8

### DIFF
--- a/jupyterlite/requirements.txt
+++ b/jupyterlite/requirements.txt
@@ -1,11 +1,11 @@
 # Core modules (mandatory)
-jupyterlite-core==0.6.4
-jupyterlab~=4.4.5
-notebook~=7.4.5
+jupyterlite-core==0.8.0
+jupyterlab~=4.6.0
+notebook~=7.6.0
 
 
 # Python kernel (optional)
-jupyterlite-pyodide-kernel==0.6.1
+jupyterlite-pyodide-kernel==0.8.1
 
 # Language support (optional)
 jupyterlab-language-pack-fr-FR


### PR DESCRIPTION
Bumps JupyterLite to the latest 0.8 line.

| Package | Before | After |
|---|---|---|
| `jupyterlite-core` | 0.6.4 | 0.8.0 |
| `jupyterlite-pyodide-kernel` | 0.6.1 | 0.8.1 |
| `jupyterlab` | `~=4.4.5` | `~=4.6.0` |
| `notebook` | `~=7.4.5` | `~=7.6.0` |

`jupyterlite-core` 0.8.0 requires `jupyterlab>=4.6.0,<4.7` and `notebook>=7.6.0,<7.7`, so those pins are bumped to match.

## Verification
Created a fresh venv, installed the updated `jupyterlite/requirements.txt`, and ran the README build command:

```
jupyter lite build --contents jupyterlite/content --output-dir <out>
```

Build completed cleanly — all federated extensions (pyodide-kernel, widgets, bqplot, ipycanvas, matplotlib, leaflet, plotly, night theme) copied and `index.html` + `api/` output generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)