### PR TITLE
Duplicating an example-sourced project drops the example identity

### DIFF
--- a/src/store/projects.integration.test.ts
+++ b/src/store/projects.integration.test.ts
@@ -948,6 +948,32 @@ describe("projects store integration", () => {
         ),
       ).not.toBeNull();
     });
+
+    it("drops example provenance so the copy's runs report their own identity (#394)", async () => {
+      const engine = createFakeEngine();
+      const { store, libraryStorage } = await createTestStore(engine);
+      await store.getActions().projects.createProject({
+        displayName: "Water vapor",
+        files: [{ fileName: "in.lmp", content: SCRIPT }],
+        source: { type: "example", exampleId: "watervapor" },
+      });
+
+      await store.getActions().projects.duplicateProject();
+
+      const copyDirName = activeDirName(store);
+      const copyMeta = await readJson<ProjectMeta>(
+        libraryStorage,
+        copyDirName,
+        PROJECT_META_PATH,
+      );
+      expect(copyMeta.source).toBeUndefined();
+
+      vi.mocked(track).mockClear();
+      await store.getActions().projects.startRuns([runRequest()]);
+      expect(byName("Simulation.Start")[0]).toMatchObject({
+        simulationId: copyDirName,
+      });
+    });
   });
 
   describe("duplicateProject: nested files and pending edits", () => {

--- a/src/store/projects.ts
+++ b/src/store/projects.ts
@@ -538,7 +538,12 @@ export const projectsModel: ProjectsModel = {
     const meta = await actions.createProject({
       displayName: `${active.meta.displayName} (copy)`,
       color: active.meta.color,
-      source: active.meta.source,
+      // A duplicate is a fork the user intends to change: drop the example
+      // identity so the copy's runs report its own dir name in metrics
+      // instead of the original example forever (#394). Other provenance
+      // (upload/blank) carries over.
+      source:
+        active.meta.source?.type === "example" ? undefined : active.meta.source,
       inputScript: active.meta.inputScript,
       files: [],
     });


### PR DESCRIPTION
Fixes #394. Stacked on #393 (retargets to main when it merges).

A duplicate is a fork the user intends to change: keeping `source.exampleId` made every future run of the copy report the original curated example as `simulationId`/`exampleId` to Mixpanel, permanently misattributing the user's own work to the example.

- `duplicateProject` drops example provenance (upload/blank provenance still carries over), so the copy's runs report its own dir name.
- `saveQuickAsProject` deliberately keeps the example identity: a saved quick run IS the example at save time, and counting it under the example is what the dashboard wants.
- Integration test: duplicate of an example-sourced project persists no `source` and its runs send `simulationId = <copy dirName>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)