### PR TITLE
simulation: metricsId is required — no silent fallback to the run path

### DIFF
--- a/src/store/simulation.test.ts
+++ b/src/store/simulation.test.ts
@@ -234,6 +234,7 @@ describe("simulation store — pure actions", () => {
 function createMockSimulation(overrides?: Partial<Simulation>): Simulation {
   return {
     id: "test-sim",
+    metricsId: "test-sim",
     files: [{ fileName: "in.lmp", content: "run 100" }],
     inputScript: "in.lmp",
     start: true,

--- a/src/store/simulation.ts
+++ b/src/store/simulation.ts
@@ -155,9 +155,11 @@ export interface Simulation {
   /**
    * Identity sent to metrics as simulationId: the curated example id when
    * the project came from the example library, else the project dir name.
-   * Falls back to `id` when unset.
+   * Required so every caller chooses an identity — a fallback to `id`
+   * would silently send per-run-unique `<dirName>/runs/run-NNN` paths and
+   * fragment the Mixpanel per-simulation breakdown (#395).
    */
-  metricsId?: string;
+  metricsId: string;
 }
 
 // The full console of the active run, outside the store: state.lammpsOutput
@@ -408,7 +410,7 @@ export const simulationModel: SimulationModel = {
       actions.setRunning(true);
       // simulationId is the curated example id or the project dir name —
       // the Mixpanel dashboard breaks simulations down by it.
-      const simulationId = simulation.metricsId ?? simulation.id;
+      const simulationId = simulation.metricsId;
       track("Simulation.Start", { simulationId });
       time_event("Simulation.Stop");
       if (inputScriptFile.content) {
@@ -558,9 +560,7 @@ export const simulationModel: SimulationModel = {
           allActions.app.setSelectedFile(inputScriptFile);
         }
       }
-      track("Simulation.New", {
-        simulationId: simulation.metricsId ?? simulation.id,
-      });
+      track("Simulation.New", { simulationId: simulation.metricsId });
     },
   ),
   setLastError: action((state, error: string | undefined) => {


### PR DESCRIPTION
Fixes #395. Stacked on #393 (retargets to main when it merges).

The `metricsId ?? simulation.id` fallback was dead code today, but any future caller that forgot to set `metricsId` would silently send per-run-unique `<dirName>/runs/run-NNN` paths as `simulationId`, fragmenting the Mixpanel per-simulation breakdown into one bucket per run.

- `Simulation.metricsId` is now required — the compiler forces every constructor to choose an identity.
- The track calls use it directly, no fallback.
- Test factory sets it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)