### PR TITLE
chore(deps-dev): upgrade typescript 4.9 -> 5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "react-dom": "^19.2.7",
         "styled-components": "^6.4.1",
         "three": "^0.181.2",
-        "typescript": "^4.9.5",
         "uuid": "^14.0.0",
         "web-vitals": "^5.1.0"
       },
@@ -50,6 +49,7 @@
         "gh-pages": "^6.1.1",
         "jsdom": "^29.0.1",
         "prettier": "3.6.2",
+        "typescript": "^5.9.3",
         "vite": "^8.1.3",
         "vitest": "^4.1.0"
       }
@@ -5432,16 +5432,17 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react-dom": "^19.2.7",
     "styled-components": "^6.4.1",
     "three": "^0.181.2",
-    "typescript": "^4.9.5",
     "uuid": "^14.0.0",
     "web-vitals": "^5.1.0"
   },
@@ -72,6 +71,7 @@
     "gh-pages": "^6.1.1",
     "jsdom": "^29.0.1",
     "prettier": "3.6.2",
+    "typescript": "^5.9.3",
     "vite": "^8.1.3",
     "vitest": "^4.1.0"
   }


### PR DESCRIPTION
Deliberate TypeScript 4.9.5 -> 5.9.3 upgrade, replacing dependabot's declined 4.9 -> 7.0 jump (#384).

- Typecheck clean, 459/459 tests pass, production build succeeds
- Unblocks #383 (@types/node 26), whose declaration files use syntax TS 4.9 cannot parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)