### PR TITLE
fix: run console collapsed by default

### DIFF
--- a/e2e/run.spec.ts
+++ b/e2e/run.spec.ts
@@ -49,6 +49,9 @@ test("run a simulation end-to-end and inspect the recorded run", async ({
     await expect(page.getByTestId("status-pill-running")).toBeVisible({
       timeout: 60_000,
     });
+    // The console defaults to collapsed; expand it to watch the live output
+    // (the choice is remembered for the session, so later steps see it open).
+    await page.getByTestId("run-console-toggle").click();
     // Live console follows the engine output.
     await expect(page.getByTestId("run-console")).toContainText("LAMMPS", {
       timeout: 60_000,

--- a/src/shell/RunDetail.tsx
+++ b/src/shell/RunDetail.tsx
@@ -68,10 +68,10 @@ const RunDetail = ({ runId }: { runId: string }) => {
   const [frameUrl, setFrameUrl] = useState<string | null>(null);
   const [outputs, setOutputs] = useState<FileStat[]>([]);
   const consoleRef = useRef<HTMLDivElement | null>(null);
-  // Collapsible console strip: default expanded, choice remembered for the
-  // session so the viewport keeps the reclaimed height across run screens.
+  // Collapsible console strip: default collapsed so the viewport gets the
+  // height; an explicit expand is remembered for the session.
   const [consoleCollapsed, setConsoleCollapsed] = useState(
-    () => sessionStorage.getItem(CONSOLE_COLLAPSED_KEY) === "1",
+    () => sessionStorage.getItem(CONSOLE_COLLAPSED_KEY) !== "0",
   );
   const toggleConsole = () =>
     setConsoleCollapsed((previous) => {


### PR DESCRIPTION
The console strip stole ~190px of viewport height on every run screen. It now defaults to collapsed; expanding it is still remembered for the session (same sessionStorage key, inverted default).

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)