### PR TITLE
fix: chart legend shows series names when not hovering

### DIFF
--- a/src/components/Figure.tsx
+++ b/src/components/Figure.tsx
@@ -150,9 +150,9 @@ export const FigureGraph = ({
           "#722ed1",
         ],
         legendFormatter: function (data) {
-          if (data.x == null) {
-            return "";
-          }
+          // Without a hovered point (data.x == null) still list the series
+          // names and colors — an empty legend box reads as a bug.
+          const hovering = data.x != null;
           let html = '<div class="dygraph-custom-legend">';
           data.series.forEach(function (series) {
             if (!series.isVisible) return;
@@ -161,7 +161,11 @@ export const FigureGraph = ({
               '<span class="dygraph-legend-dot" style="color: ' +
               color +
               ';">● </span>';
-            html += series.labelHTML + ": " + series.yHTML + "<br/>";
+            html += series.labelHTML;
+            if (hovering) {
+              html += ": " + series.yHTML;
+            }
+            html += "<br/>";
           });
           html += "</div>";
           return html;

--- a/src/index.css
+++ b/src/index.css
@@ -425,14 +425,22 @@ body,
   color: #fff !important;
   border: 1px solid #333 !important;
   border-radius: 4px !important;
-  padding: 8px !important;
+  padding: 6px 8px !important;
+  /* The legend is always visible now: shrink to content (the library
+     default is a fixed 250px), cap its footprint on small charts, and
+     never intercept pointer events meant for the plot beneath it. */
+  width: auto !important;
+  max-width: 45% !important;
+  max-height: 45% !important;
+  overflow: hidden !important;
+  font-size: 11px !important;
+  line-height: 1.5 !important;
+  pointer-events: none !important;
 }
 
 .dygraph-custom-legend {
-  background: rgba(0, 0, 0, 0.8);
-  padding: 8px;
-  border-radius: 4px;
   color: #fff;
+  white-space: nowrap;
 }
 
 .dygraph-legend-dot {


### PR DESCRIPTION
The dygraphs `legendFormatter` returned an empty string whenever `data.x == null` (no hovered point), so the `legend: "always"` box rendered as an empty rectangle. The legend now always lists the series names with their color dots; hovering additionally shows the values, exactly as before.

Fixes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)