### PR TITLE
feat: collapsible sidebar

### DIFF
--- a/src/shell/Shell.test.tsx
+++ b/src/shell/Shell.test.tsx
@@ -110,6 +110,29 @@ describe("Shell", () => {
     expect(localStorage.getItem("atomify_theme")).toBe("light");
   });
 
+  it("collapses the sidebar to an icon rail and persists the choice", async () => {
+    renderShell();
+
+    const sidebar = screen.getByTestId("sidebar");
+    expect(sidebar.getAttribute("data-collapsed")).toBe("false");
+    expect(screen.getByTestId("nav-examples")).toHaveTextContent(
+      "Example library",
+    );
+
+    await userEvent.click(screen.getByTestId("sidebar-collapse"));
+
+    expect(sidebar.getAttribute("data-collapsed")).toBe("true");
+    // Icon rail: the nav buttons stay clickable but drop their labels.
+    expect(screen.getByTestId("nav-examples")).not.toHaveTextContent(
+      "Example library",
+    );
+    expect(localStorage.getItem("atomify_sidebar_collapsed")).toBe("1");
+
+    await userEvent.click(screen.getByTestId("sidebar-collapse"));
+    expect(sidebar.getAttribute("data-collapsed")).toBe("false");
+    expect(localStorage.getItem("atomify_sidebar_collapsed")).toBe("0");
+  });
+
   it("navigates to the example library and shows fetched examples", async () => {
     renderShell();
 

--- a/src/shell/Sidebar.tsx
+++ b/src/shell/Sidebar.tsx
@@ -2,9 +2,11 @@
  * Global sidebar (ADR-003 §2): Home, Example library, the PROJECTS list with
  * color dots + running pulse, New project, and a footer with the theme
  * toggle, Settings, and the engine-loading chip (loading never blocks
- * browsing — ADR-003 §6).
+ * browsing — ADR-003 §6). Collapsible to a narrow icon rail (persisted) so
+ * the simulation gets the horizontal room.
  */
 
+import { useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { useStoreActions, useStoreState } from "../hooks";
 import type { ThemeName } from "../store/settings";
@@ -12,6 +14,7 @@ import { track } from "../utils/metrics";
 import { useShellUI } from "./ShellContext";
 import {
   AtomLogo,
+  ChevronRightIcon,
   GridIcon,
   HomeIcon,
   MoonIcon,
@@ -21,12 +24,16 @@ import {
 } from "./icons";
 import { ColorDot, PulseDot } from "./ui";
 
-const navButtonStyle = (active: boolean): CSSProperties => ({
+/** Persisted collapse choice — the rail should survive reloads. */
+const SIDEBAR_COLLAPSED_KEY = "atomify_sidebar_collapsed";
+
+const navButtonStyle = (active: boolean, collapsed: boolean): CSSProperties => ({
   display: "flex",
   alignItems: "center",
-  gap: 11,
+  justifyContent: collapsed ? "center" : "flex-start",
+  gap: collapsed ? 0 : 11,
   width: "100%",
-  padding: "8px 12px",
+  padding: collapsed ? "9px 0" : "8px 12px",
   borderRadius: 10,
   border: "none",
   cursor: "pointer",
@@ -40,22 +47,28 @@ const navButtonStyle = (active: boolean): CSSProperties => ({
 
 const NavButton = ({
   active,
+  collapsed,
   onClick,
-  children,
+  icon,
+  label,
   testId,
 }: {
   active: boolean;
+  collapsed: boolean;
   onClick: () => void;
-  children: ReactNode;
+  icon: ReactNode;
+  label: string;
   testId?: string;
 }) => (
   <button
     onClick={onClick}
     data-testid={testId}
+    title={collapsed ? label : undefined}
     className={active ? undefined : "shell-hoverable"}
-    style={navButtonStyle(active)}
+    style={navButtonStyle(active, collapsed)}
   >
-    {children}
+    {icon}
+    {!collapsed && label}
   </button>
 );
 
@@ -76,6 +89,20 @@ const Sidebar = () => {
   );
   const ui = useShellUI();
 
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1",
+  );
+  const toggleCollapsed = () =>
+    setCollapsed((previous) => {
+      const next = !previous;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, next ? "1" : "0");
+      } catch {
+        // best effort
+      }
+      return next;
+    });
+
   const themeButtonStyle = (mode: "dark" | "light"): CSSProperties => ({
     width: 30,
     height: 28,
@@ -89,11 +116,39 @@ const Sidebar = () => {
     color: theme === mode ? "#fff" : "var(--text-3)",
   });
 
+  const collapseButton = (
+    <button
+      onClick={toggleCollapsed}
+      title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      aria-expanded={!collapsed}
+      data-testid="sidebar-collapse"
+      className="shell-hoverable shell-hoverable-text"
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: 7,
+        border: "none",
+        background: "transparent",
+        color: "var(--text-3)",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transform: collapsed ? "none" : "rotate(180deg)",
+        flexShrink: 0,
+      }}
+    >
+      <ChevronRightIcon size={15} />
+    </button>
+  );
+
   return (
     <aside
       data-testid="sidebar"
+      data-collapsed={collapsed ? "true" : "false"}
       style={{
-        width: 252,
+        width: collapsed ? 64 : 252,
         flexShrink: 0,
         height: "100%",
         display: "flex",
@@ -103,34 +158,49 @@ const Sidebar = () => {
       }}
     >
       <div
-        onClick={() => setScreen({ name: "home" })}
-        data-testid="sidebar-logo"
         style={{
           display: "flex",
+          flexDirection: collapsed ? "column" : "row",
           alignItems: "center",
-          gap: 11,
-          padding: "20px 18px 16px",
-          cursor: "pointer",
+          gap: collapsed ? 6 : 11,
+          padding: collapsed ? "16px 0 10px" : "20px 18px 16px",
         }}
       >
-        <AtomLogo />
-        <span
+        <div
+          onClick={() => setScreen({ name: "home" })}
+          data-testid="sidebar-logo"
           style={{
-            fontWeight: 800,
-            fontSize: 17,
-            letterSpacing: "-0.02em",
-            color: "var(--text)",
+            display: "flex",
+            alignItems: "center",
+            gap: 11,
+            cursor: "pointer",
+            minWidth: 0,
+            flex: collapsed ? undefined : 1,
           }}
         >
-          Atomify
-        </span>
+          <AtomLogo />
+          {!collapsed && (
+            <span
+              style={{
+                fontWeight: 800,
+                fontSize: 17,
+                letterSpacing: "-0.02em",
+                color: "var(--text)",
+              }}
+            >
+              Atomify
+            </span>
+          )}
+        </div>
+        {collapseButton}
       </div>
 
       <nav
         style={{
           flex: 1,
           overflowY: "auto",
-          padding: "0 12px 16px",
+          overflowX: "hidden",
+          padding: collapsed ? "0 10px 16px" : "0 12px 16px",
           display: "flex",
           flexDirection: "column",
           gap: 2,
@@ -138,40 +208,42 @@ const Sidebar = () => {
       >
         <NavButton
           active={screen.name === "home"}
+          collapsed={collapsed}
           onClick={() => setScreen({ name: "home" })}
+          icon={<HomeIcon />}
+          label="Home"
           testId="nav-home"
-        >
-          <HomeIcon />
-          Home
-        </NavButton>
+        />
         <NavButton
           active={screen.name === "examples"}
+          collapsed={collapsed}
           onClick={() => setScreen({ name: "examples" })}
+          icon={<GridIcon />}
+          label="Example library"
           testId="nav-examples"
-        >
-          <GridIcon />
-          Example library
-        </NavButton>
+        />
 
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            justifyContent: "space-between",
-            padding: "18px 12px 7px",
+            justifyContent: collapsed ? "center" : "space-between",
+            padding: collapsed ? "16px 0 5px" : "18px 12px 7px",
           }}
         >
-          <span
-            style={{
-              fontSize: 11,
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.07em",
-              color: "var(--text-3)",
-            }}
-          >
-            Projects
-          </span>
+          {!collapsed && (
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.07em",
+                color: "var(--text-3)",
+              }}
+            >
+              Projects
+            </span>
+          )}
           <button
             onClick={() => ui.openNewProject()}
             title="New project"
@@ -203,13 +275,15 @@ const Sidebar = () => {
               key={project.dirName}
               onClick={() => openProject({ dirName: project.dirName })}
               data-testid={`sidebar-project-${project.dirName}`}
+              title={collapsed ? project.displayName : undefined}
               className={active ? undefined : "shell-hoverable"}
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: 10,
+                justifyContent: collapsed ? "center" : "flex-start",
+                gap: collapsed ? 0 : 10,
                 width: "100%",
-                padding: "7px 12px",
+                padding: collapsed ? "9px 0" : "7px 12px",
                 borderRadius: 9,
                 border: "none",
                 cursor: "pointer",
@@ -218,119 +292,166 @@ const Sidebar = () => {
                 fontWeight: active ? 700 : 500,
                 fontSize: 13.5,
                 fontFamily: "inherit",
+                position: "relative",
               }}
             >
               <ColorDot color={project.color} />
-              <span
-                style={{
-                  flex: 1,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                  textAlign: "left",
-                }}
-              >
-                {project.displayName}
-              </span>
-              {running && <PulseDot />}
+              {!collapsed && (
+                <span
+                  style={{
+                    flex: 1,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    textAlign: "left",
+                  }}
+                >
+                  {project.displayName}
+                </span>
+              )}
+              {running &&
+                (collapsed ? (
+                  <span style={{ position: "absolute", top: 4, right: 8 }}>
+                    <PulseDot size={5} />
+                  </span>
+                ) : (
+                  <PulseDot />
+                ))}
             </button>
           );
         })}
 
-        <button
-          onClick={() => ui.openNewProject()}
-          data-testid="sidebar-new-project"
-          className="shell-dashed-hover"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 10,
-            padding: "8px 12px",
-            borderRadius: 10,
-            border: "1px dashed var(--border-strong)",
-            background: "transparent",
-            color: "var(--text-3)",
-            fontWeight: 600,
-            fontSize: 13,
-            fontFamily: "inherit",
-            cursor: "pointer",
-            marginTop: 6,
-          }}
-        >
-          <PlusIcon />
-          New project
-        </button>
+        {!collapsed && (
+          <button
+            onClick={() => ui.openNewProject()}
+            data-testid="sidebar-new-project"
+            className="shell-dashed-hover"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: "1px dashed var(--border-strong)",
+              background: "transparent",
+              color: "var(--text-3)",
+              fontWeight: 600,
+              fontSize: 13,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              marginTop: 6,
+            }}
+          >
+            <PlusIcon />
+            New project
+          </button>
+        )}
       </nav>
 
       {!ui.engineReady && (
         <div
           data-testid="engine-loading-chip"
+          title={
+            collapsed
+              ? `Engine loading…${status ? ` ${Math.ceil(100 * status.progress)}%` : ""}`
+              : undefined
+          }
           style={{
-            margin: "0 12px 10px",
-            padding: "8px 12px",
+            margin: collapsed ? "0 10px 10px" : "0 12px 10px",
+            padding: collapsed ? "8px 0" : "8px 12px",
             borderRadius: 9,
             background: "var(--surface-2)",
             border: "1px solid var(--border)",
             display: "flex",
             alignItems: "center",
+            justifyContent: collapsed ? "center" : "flex-start",
             gap: 9,
             fontSize: 12,
             color: "var(--text-2)",
           }}
         >
           <PulseDot size={7} />
-          <span style={{ flex: 1 }}>
-            Engine loading…
-            {status ? ` ${Math.ceil(100 * status.progress)}%` : ""}
-          </span>
+          {!collapsed && (
+            <span style={{ flex: 1 }}>
+              Engine loading…
+              {status ? ` ${Math.ceil(100 * status.progress)}%` : ""}
+            </span>
+          )}
         </div>
       )}
 
       <div
         style={{
-          padding: 12,
+          padding: collapsed ? "12px 10px" : 12,
           borderTop: "1px solid var(--border)",
           display: "flex",
+          flexDirection: collapsed ? "column" : "row",
           gap: 8,
           alignItems: "center",
         }}
       >
-        <div
-          style={{
-            display: "flex",
-            background: "var(--surface-2)",
-            borderRadius: 9,
-            padding: 3,
-            gap: 2,
-          }}
-        >
+        {collapsed ? (
           <button
-            onClick={() => changeTheme("dark")}
-            title="Dark"
-            data-testid="theme-dark"
-            style={themeButtonStyle("dark")}
+            onClick={() => changeTheme(theme === "dark" ? "light" : "dark")}
+            title={theme === "dark" ? "Switch to light" : "Switch to dark"}
+            data-testid="theme-flip"
+            className="shell-hoverable shell-hoverable-text"
+            style={{
+              width: 30,
+              height: 28,
+              borderRadius: 7,
+              border: "none",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "transparent",
+              color: "var(--text-3)",
+            }}
           >
-            <MoonIcon />
+            {theme === "dark" ? <SunIcon /> : <MoonIcon />}
           </button>
-          <button
-            onClick={() => changeTheme("light")}
-            title="Light"
-            data-testid="theme-light"
-            style={themeButtonStyle("light")}
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              background: "var(--surface-2)",
+              borderRadius: 9,
+              padding: 3,
+              gap: 2,
+            }}
           >
-            <SunIcon />
-          </button>
-        </div>
+            <button
+              onClick={() => changeTheme("dark")}
+              title="Dark"
+              data-testid="theme-dark"
+              style={themeButtonStyle("dark")}
+            >
+              <MoonIcon />
+            </button>
+            <button
+              onClick={() => changeTheme("light")}
+              title="Light"
+              data-testid="theme-light"
+              style={themeButtonStyle("light")}
+            >
+              <SunIcon />
+            </button>
+          </div>
+        )}
         <button
           onClick={() => ui.openSettings()}
           data-testid="sidebar-settings"
+          title={collapsed ? "Settings" : undefined}
           className="shell-hoverable shell-hoverable-text"
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 10,
-            flex: 1,
-            padding: "8px 10px",
+            justifyContent: collapsed ? "center" : "flex-start",
+            gap: collapsed ? 0 : 10,
+            flex: collapsed ? undefined : 1,
+            width: collapsed ? 30 : undefined,
+            padding: collapsed ? "6px 0" : "8px 10px",
             borderRadius: 9,
             border: "none",
             background: "transparent",
@@ -342,7 +463,7 @@ const Sidebar = () => {
           }}
         >
           <SlidersIcon />
-          Settings
+          {!collapsed && "Settings"}
         </button>
       </div>
     </aside>

--- a/src/shell/Sidebar.tsx
+++ b/src/shell/Sidebar.tsx
@@ -89,9 +89,13 @@ const Sidebar = () => {
   );
   const ui = useShellUI();
 
-  const [collapsed, setCollapsed] = useState(
-    () => localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1",
-  );
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
   const toggleCollapsed = () =>
     setCollapsed((previous) => {
       const next = !previous;


### PR DESCRIPTION
The left sidebar can now collapse to a 64px icon rail via a chevron toggle next to the logo, giving the simulation the horizontal room. Collapsed mode keeps everything reachable: nav icons + project color dots get tooltips, the running pulse moves to a corner badge, the footer becomes a theme-flip button + settings icon. The choice persists in localStorage (`atomify_sidebar_collapsed`).

Covered by a new Shell integration test (collapse → rail, persist, expand).

Fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)